### PR TITLE
Refresh curriculum architecture and deepen learning tracks

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -48,14 +48,15 @@ jobs:
       run: |
         cat > claude-interaction.js << 'EOF'
         const Anthropic = require('@anthropic-ai/sdk');
-        const { Octokit } = require('@octokit/rest');
         const fs = require('fs');
-        
+
         async function main() {
           const anthropic = new Anthropic({
             apiKey: process.env.CLAUDE_API_KEY,
           });
-          
+
+          const { Octokit } = await import('@octokit/rest');
+
           const octokit = new Octokit({
             auth: process.env.GITHUB_TOKEN,
           });

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -17,7 +17,6 @@ jobs:
           args: >-
             --verbose
             --no-progress
-            --exclude-mail
             --max-redirects 5
             './**/*.md' './docs/**/*.html'
         env:

--- a/02-learning-paths/100-hour-ai-architect.md
+++ b/02-learning-paths/100-hour-ai-architect.md
@@ -1,32 +1,46 @@
-# 100‑Hour AI Architect Plan
+# 100‑Hour AI Architect Plan — Launchpad Sprint
 
-Format: 4 weeks × ~25 hours/week. Focus on shipping real artifacts weekly.
+Format: 4 weeks × ~25 hours/week. Blend async deep dives (12h), guided labs (8h), and reflection/storytelling (5h).
 
-Week 1 — Foundations (25h)
-- LLM basics (6h): tokenization, attention, prompting
-- Retrieval & embeddings (8h): chunking, hybrid search, pgvector
-- Hands‑on (8h): implement vector search; small RAG demo
-- Assessment (3h): quiz + short write‑up
+## Program Outcomes
+- Ship a production-grade retrieval pipeline (ingestion → hybrid search → rerank → answer) with citations.
+- Instrument evaluation and observability from day one (Langfuse or OSS equivalent, prompt regression tests, cost/latency dashboards).
+- Document architecture, governance decisions, and value narrative that convinces stakeholders to scale.
 
-Week 2 — Systems (25h)
-- Agents & tools (6h): function calling, orchestration
-- Observability & evals (6h): Langfuse, metrics, datasets
-- Hands‑on (10h): RAG with citations and eval harness
-- Assessment (3h): demo + reflection
+## Weekly Breakdown
+| Week | Focus | Key Work | Time Split |
+| --- | --- | --- | --- |
+| **Week 1 — Foundations & Retrieval** | Tokenization, attention, prompting systems, embedding strategy | Build dataset ingestion notebook, compare embedding models, implement pgvector hybrid search | 6h theory · 6h lab · 4h reading · 3h reflection · 6h optional dojo |
+| **Week 2 — Systems & Agents** | Tool use, function calling, orchestration strategies, context windows | Extend RAG app with tool-enabled agent, implement reranking, add streaming UX | 5h theory · 8h lab · 4h pairing · 4h research · 4h reflection |
+| **Week 3 — Evaluation, Observability & Governance** | Metrics, eval harnesses, tracing, privacy, model risk | Wire Langfuse traces, run prompt regression suite, map privacy controls, create incident playbook | 5h theory · 8h lab · 5h ops reviews · 3h governance · 4h storytelling |
+| **Week 4 — Specialisation & Portfolio** | Industry deep dives, optimisation, stakeholder influence | Optimise latency/cost, integrate guardrails, produce architecture brief, record final demo | 4h theory · 9h lab · 4h stakeholder interviews · 4h storytelling · 4h retros |
 
-Week 3 — Governance & Performance (25h)
-- Privacy/GDPR (4h), model risk (4h)
-- Performance & cost (6h): caching, batch, smaller models
-- Hands‑on (8h): optimize RAG; add guardrails
-- Assessment (3h): doc architecture & SLOs
+## Daily Cadence
+- **Mon:** 90-minute async module + guided exercise (LLM fundamentals, retrieval research, architecture patterns).
+- **Tue:** Live lab (mob build) on ingestion, retrieval, or orchestration. Pair using the [vector search project](../05-projects/vector-search-pgvector.md).
+- **Wed:** Evaluation dojo — implement metrics, prompt tests, and compare outputs. Review with Langfuse traces or `promptfoo` harness.
+- **Thu:** Governance & systems clinic — apply privacy, policy, and incident checklists from `08-governance/`.
+- **Fri:** Portfolio studio — write weekly recap, capture demo, update architecture doc, and share in cohort channel.
 
-Week 4 — Specialization & Portfolio (25h)
-- Industry pattern (6h): choose domain
-- Project (15h): complete end‑to‑end PoC
-- Presentation (4h): writeup + slides + video
+## Deliverables & Rubrics
+- **Working RAG app with citations and fallback path** (functionality 40%).
+- **Evaluation dossier** containing metrics, regression logs, and mitigation notes (rigor 25%).
+- **Operations dashboard** covering latency, cost, and usage patterns (observability 15%).
+- **Architecture narrative** (doc + diagram + 3-minute video) aligned with exec questions (storytelling 20%).
 
-Deliverables
-- Working RAG app with citations
-- Eval report with metrics
-- Architecture doc (diagram, SLOs, costs)
-- Final presentation
+## Recommended Toolchain
+- **Models:** GPT-4.1, Claude 3.5 Sonnet, Llama 3 70B, or Mistral Large — swap using [LiteLLM](../06-toolchains/stack-reference.md#litellm).
+- **Vector & retrieval:** Supabase pgvector, Weaviate, or Milvus; embed with OpenAI `text-embedding-3-large`, Cohere Embed v3, or Voyage-large-2.
+- **Evaluation:** Langfuse, OpenAI Evals, `promptfoo`, or LangSmith. Pair with Phoenix for trace inspection.
+- **Observability:** OpenTelemetry exporters, custom dashboards, cost logging via your cloud provider.
+
+## Suggested Reading & Research
+- Retrieval best practices: [Hybrid search playbook](../03-awesome/retrieval.md)
+- Evaluation patterns: [Metrics](../07-evaluation/metrics.md), [Eval harness](../07-evaluation/eval-harness.md)
+- Governance & risk: [Model risk framework](../08-governance/model-risk.md), [Privacy & GDPR](../08-governance/privacy-gdpr.md)
+- Storytelling: [Executive brief template](../04-templates/executive-brief.md), [Brand Voice](../BRAND-VOICE.md)
+
+## Next Steps After Launchpad
+- Roll into the [Professional Architect Studio](professional.md) for multi-model orchestration, or
+- Support executive adoption via the [AI CoE Bootcamp](bootcamp.md), and
+- Deepen agentic workflows inside the [Agentic Systems Lab](agentic-code-swarms.md).

--- a/02-learning-paths/agentic-code-swarms.md
+++ b/02-learning-paths/agentic-code-swarms.md
@@ -1,9 +1,16 @@
 # Learning Path: Agentic Code Swarms
 
-Audience: AI Architects and Builders using Codex, Claude Code, or Cursor.
-Outcome: Ship a working multi-agent swarm, understand orchestration patterns, and build a visual explorer.
+Audience: AI Architects and Builders using Codex, Claude Code, Cursor, or other pair-programming copilots.
+Outcome: Ship a working multi-agent swarm, understand orchestration patterns, and build a visual explorer with live telemetry.
 
 Time: 10–16 hours (self-paced)
+
+This lab is the capstone inside the [Agentic Systems Lab](curriculum-architecture.md#program-layers--flagship-outcomes). Pair it with the [Professional Studio](professional.md) for evaluation depth and the [Bootcamp](bootcamp.md) to socialise operating models with leadership.
+
+## Curriculum Placement
+- **Prerequisite:** Comfortable with the [100-Hour Launchpad](100-hour-ai-architect.md) retrieval pipeline and evaluation loop.
+- **Parallel tracks:** Join weekly design reviews with Professional Studio cohorts to compare orchestrator decisions and failure modes.
+- **Post-lab moves:** Publish your swarm pattern as a case study in `01-design-patterns/` or demo it during a bootcamp executive council.
 
 ## Prereqs
 - Python 3.11

--- a/02-learning-paths/beginner.md
+++ b/02-learning-paths/beginner.md
@@ -1,5 +1,31 @@
-# Beginner Path (4 Weeks)
-- Week 1: LLM basics, prompting, safety
-- Week 2: Retrieval & embeddings, pgvector
-- Week 3: Agents & tools, orchestration
-- Week 4: Evaluation & observability
+# Beginner Path — Creator Launch Sequence (4 Weeks)
+
+Designed for creators, educators, and advocates who want to teach AI architecture responsibly. Expect ~8–10 hours per week across async study, micro-builds, and storytelling.
+
+## Outcomes
+- Explain core AI architecture concepts with clarity (retrieval, agents, evaluation, governance).
+- Facilitate workshops or community sessions that demonstrate safe prompting and responsible usage.
+- Publish at least three artifacts (newsletter, tutorial, talk track) aligned with the Brand Voice playbook.
+
+## Weekly Flow
+| Week | Focus | Key Activities | Teaching Assets |
+| --- | --- | --- | --- |
+| **Week 1 — Narrative Foundations** | Positioning, personas, value loops | Study [START-HERE](../START-HERE.md), craft audience personas, map value loop storyboard, draft welcome newsletter | [Brand Voice](../BRAND-VOICE.md), [Experience guide](../docs/experience.html) |
+| **Week 2 — Retrieval & Prompt Craft** | Prompt design, retrieval mental models, safe defaults | Run mini RAG lab using [vector search](../05-projects/vector-search-pgvector.md), capture screenshots, create cheat sheet | [Design Patterns](../01-design-patterns/), [Resources hub](../10-resources/) |
+| **Week 3 — Governance & Trust Signals** | Privacy, risk, evaluation narratives | Summarise [privacy](../08-governance/privacy-gdpr.md) & [model risk](../08-governance/model-risk.md) into workshop slides, design "trust checklist" handout | [Governance checklists](../08-governance/checklists.md), [Metrics](../07-evaluation/metrics.md) |
+| **Week 4 — Launch & Amplify** | Community delivery, storytelling, feedback loops | Host a live session or recorded tutorial, publish recap article, solicit feedback for iteration | [Article outlines](../09-articles/), [Collaboration playbook](../16-collaboration/working-with-ai.md) |
+
+## Teaching Model
+- **Micro-drops.** 20-minute videos or async primers paired with practice prompts so learners can teach the content immediately.
+- **Office hours.** Weekly 45-minute clinics to critique decks, review tutorials, and adjust messaging.
+- **Peer review.** Participants swap scripts, slides, and demos for critique using `16-collaboration/peer-review.md`.
+
+## Portfolio Checklist
+- Welcome or announcement email/newsletter.
+- 30–45 minute workshop outline including demos, risks, and Q&A prompts.
+- Visual explainer (slide, infographic, or short-form video) linking to the repo and encouraging cloning.
+
+## Next Moves
+- Transition into the [Professional Architect Studio](professional.md) once you’re ready to ship complex systems.
+- Partner with executives by attending the [AI CoE Bootcamp](bootcamp.md).
+- Contribute back: submit your workshop templates to `04-templates/` and record learnings in `example-sessions/`.

--- a/02-learning-paths/bootcamp.md
+++ b/02-learning-paths/bootcamp.md
@@ -1,4 +1,39 @@
-# Bootcamp Path (AI CoE Inspired)
-- Week 1: Core patterns & CX
-- Week 2: Architecture, vector search, integration, performance, governance
-- Week 3: Industry, agents, PoC & presentation
+# Bootcamp Path — AI Center of Excellence Alignment
+
+Three intensive weeks for heads of AI, platform leaders, and cross-functional squads. Designed to align roadmap, governance, budget, and talent around measurable outcomes. Plan for 12–14 hours per week plus two executive councils.
+
+## Bootcamp Outcomes
+- Shared AI operating model (vision, value loops, operating cadence) grounded in current capabilities and risk appetite.
+- Platform architecture decision with vendor comparison, cost/latency forecasts, and integration backlog.
+- Governance baseline covering privacy, security, compliance, incident response, and responsible AI commitments.
+
+## Weekly Agenda
+| Week | Council & Focus | Key Sessions | Artefacts |
+| --- | --- | --- | --- |
+| **Week 1 — Diagnose & Frame** | Council: product + exec sponsors | Experience walkthrough, stakeholder interviews, capability mapping, risk heatmap | Vision brief, capability matrix, stakeholder map |
+| **Week 2 — Architect & Decide** | Council: platform + engineering leads | Platform matrix review, retrieval & agent demos, cost modelling, integration sequencing | Platform scorecard, integration backlog, budget plan |
+| **Week 3 — Govern & Launch** | Council: legal, compliance, data, security | Policy workshops, incident tabletop, measurement framework, communications plan | Governance playbook, KPI dashboard draft, rollout narrative |
+
+## Daily Rhythm (per week)
+- **Day 1:** 90-minute briefing (experience map, roadmap, best-in-class benchmarks) followed by executive working session.
+- **Day 2:** Technical deep dive — review architecture options, integration requirements, security posture.
+- **Day 3:** Governance workshop using `08-governance/` templates plus risk scenario drills.
+- **Day 4:** Metrics & evaluation clinic leveraging [metrics](../07-evaluation/metrics.md), `promptfoo` harnesses, and Langfuse dashboards.
+- **Day 5:** Story & alignment — craft executive update, Q&A rehearsal, and action plan.
+
+## Toolkits & References
+- **Strategy:** [Roadmap](../00-roadmap/ROADMAP.md), [Experience guide](../docs/experience.html), [Design patterns](../01-design-patterns/).
+- **Governance:** [Privacy & GDPR](../08-governance/privacy-gdpr.md), [Model risk](../08-governance/model-risk.md), [Checklists](../08-governance/checklists.md), [Policy templates](../08-governance/policy-templates.md).
+- **Operations:** [Observability playbook](../15-workflows/observability-playbook.md), [Collaboration rituals](../16-collaboration/), [Evaluation harness](../07-evaluation/eval-harness.md).
+- **Communications:** [Executive brief](../04-templates/executive-brief.md), [Town hall agenda](../04-templates/town-hall.md), [Brand Voice](../BRAND-VOICE.md).
+
+## Assessment & Success Signals
+- **Alignment (30%)** — Clarity of shared vision, prioritised capability map, stakeholder sign-off.
+- **Architecture (30%)** — Quality of platform decision, integration plan, budget and SLO targets.
+- **Governance (25%)** — Coverage of policies, risk mitigation plan, incident response readiness.
+- **Storytelling (15%)** — Executive-ready narrative, communications plan, and feedback loop.
+
+## Post-Bootcamp Actions
+- Assign owners for roadmap initiatives and governance rituals (`16-collaboration/weekly-sync.md`).
+- Launch a cross-functional observability rollout with the [Professional Studio](professional.md) team.
+- Track progress with quarterly reviews mapped to the [Curriculum Architecture](curriculum-architecture.md) to keep cohorts aligned.

--- a/02-learning-paths/curriculum-architecture.md
+++ b/02-learning-paths/curriculum-architecture.md
@@ -1,0 +1,41 @@
+# AI Architect Curriculum Architecture
+
+Design the most capable AI architects on the planet. This map shows how every learner moves from foundations to executive-level influence with clear feedback loops, live build labs, and evergreen research refreshes.
+
+## Program Layers & Flagship Outcomes
+| Layer | Duration & Cadence | Primary Persona | Focus & Flagship Deliverables | Core Assets |
+| --- | --- | --- | --- | --- |
+| **Launchpad — 100-Hour Architect Sprint** | 4 weeks · 25 h/week · mix of async lessons + 2 live labs | Hands-on builders, technical founders | Ship a production-ready retrieval pipeline with eval harness, instrument costs, publish an architecture brief | [100-hour AI Architect](100-hour-ai-architect.md), [RAG on Supabase](../05-projects/rag-on-supabase.md), [Eval Harness](../05-projects/evals-langfuse.md) |
+| **Creator Launch Sequence** | 4 weeks · 8–10 h/week · cohort-friendly | Creators, community leads, educators | Translate key concepts into workshops, articles, and explainer assets while demonstrating safe prompting patterns | [Beginner Path](beginner.md), [Article Outlines](../09-articles/), [Brand Voice](../BRAND-VOICE.md) |
+| **Professional Architect Studio** | 6 weeks · 12–15 h/week · weekly design reviews | Staff/principal architects, AI product leads | Orchestrate multi-model systems, deploy eval+observability stack, defend trade-offs in exec review | [Professional Path](professional.md), [Design Patterns](../01-design-patterns/), [Observability Playbook](../15-workflows/observability-playbook.md) |
+| **AI CoE Bootcamp** | 3 intensive weeks · 2 executive councils/week | Heads of AI, platform leaders, cross-functional squads | Align roadmap, governance, and platform choices; produce a board-ready adoption plan | [Bootcamp Path](bootcamp.md), [Governance Toolkit](../08-governance/), [Collaboration Rituals](../16-collaboration/) |
+| **Agentic Systems Lab** | 2–4 week studio · blended async + live swarm critiques | Applied researchers, advanced builders | Design resilient agentic workflows with tracing, guardrails, and evaluation loops | [Agentic Code Swarms](agentic-code-swarms.md), [Agentic SaaS Planner](../05-projects/agentic-saas-planner.md), [Metrics](../07-evaluation/metrics.md) |
+
+## Learning Rhythms & Teaching Model
+- **Weekly value loop.** Every layer follows Discover → Build → Measure → Share. Learners interview a stakeholder, ship an incremental artifact, wire evals, then publish a recap.
+- **Blended delivery.** Asynchronous primers cover theory. Live labs (90 minutes) focus on joint builds, troubleshooting, and peer critique. Daily Slack/email nudges surface micro-challenges.
+- **Proof over lectures.** Each sprint ends with evidence: working code, observability dashboards, governance decisions, and narrative assets.
+- **Stack agility.** Patterns reference up-to-date tools (OpenAI GPT-4.1, Claude 3.5 Sonnet, Llama 3, Mistral Large, LangGraph, LlamaIndex, LiteLLM, Weaviate/Supabase vector, OpenTelemetry) while emphasising vendor-agnostic principles.
+
+## Curriculum Pillars & Depth
+1. **Architectural Foundations.** Retrieval paradigms, hybrid search, structured prompting, evaluation metrics, latency/cost budgeting. Updated quarterly with latest retrieval research, embedding benchmarks, and context-windows studies.
+2. **Systems Orchestration.** Agents, planners, workflow engines, and streaming UX. Learners compare LangGraph, CrewAI, AutoGen, and open-source orchestrators to model trade-offs.
+3. **Trust, Safety, and Governance.** Privacy frameworks (GDPR, NIST AI RMF), model-risk scoring, incident response, red-teaming, and policy automation. Bootcamp maps policy to shipping rituals.
+4. **Observability & Operations.** Langfuse tracing, Phoenix/LlamaIndex diagnostics, structured logging, OpenTelemetry pipelines, cost observability, eval-driven regression alerts.
+5. **Story & Influence.** Portfolio building, stakeholder communications, executive storytelling, go-to-market narratives, pricing/value calculators, and community activation.
+
+## Feedback, Assessment, and Credentialing
+- **Rubrics.** Shared rubric templates live in `15-workflows/` and emphasise functionality (40%), clarity (30%), governance & reliability (20%), and storytelling (10%).
+- **Eval-first grading.** All projects must log metrics via Langfuse (or an equivalent open-source stack), run prompt regression tests (`promptfoo`, `langsmith`, or custom harness), and document mitigations.
+- **Signals & badges.** Finishers receive shareable artifacts: architecture briefs, guardrail policy packs, and video demos ready for clients or internal sponsors.
+
+## Continuous Research & Refresh Cycle
+- **Monthly intel sweep.** Curators refresh references across `03-awesome/` and `10-resources/` with the latest benchmarks (e.g., Massive Multitask Language Understanding, HEIM, and Retrieval Augmented Generation Leaderboards) and new governance guidance.
+- **Quarterly curriculum ship.** Every quarter we run a release sprint: update metrics guidance, include new model capabilities, revise toolchain recommendations, and expand sector-specific case studies.
+- **Community feedback.** Cohort retros, GitHub issues, and Slack polls feed directly into `00-roadmap/ROADMAP.md` so the academy stays responsive.
+
+## How to Use This Map
+1. **Pick your layer** based on persona and immediate stakes. Start with Launchpad if you need hands-on evidence fast.
+2. **Pair with the Experience Hub** ([docs/experience.html](../docs/experience.html)) to see navigation, visuals, and search in action.
+3. **Clone and customise.** Adapt modules to your team’s tooling, swap providers using `06-toolchains/`, and embed your own datasets.
+4. **Report back.** Log wins, blockers, and requests in `16-collaboration/weekly-sync.md` or open an issue. The curriculum is built to evolve with you.

--- a/02-learning-paths/professional.md
+++ b/02-learning-paths/professional.md
@@ -1,3 +1,40 @@
-# Professional Path (6 Weeks)
-- Foundations → Systems → Governance → Specialization
-- Projects: RAG on Supabase, Eval harness, Agentic workflow
+# Professional Path — Architect Studio (6 Weeks)
+
+For staff/principal architects, AI product leads, and senior builders who need to orchestrate reliable, multi-model systems. Expect 12–15 hours per week with weekly design reviews and exec-facing presentations.
+
+## Outcomes
+- Design and deploy end-to-end architectures that combine retrieval, tool-enabled agents, and domain-specific adapters.
+- Operationalise evaluation, observability, and governance with measurable SLOs and incident playbooks.
+- Influence stakeholders using quantified trade-offs, cost models, and portfolio-ready narratives.
+
+## Weekly Blueprint
+| Week | Theme | Systems Focus | Labs & Deliverables |
+| --- | --- | --- | --- |
+| **1 — Discovery & Patterns** | Align on business goals, value loops, and risk posture | Pattern selection, capability map, stakeholder interviews | Discovery brief, architecture hypothesis, stakeholder playback |
+| **2 — Retrieval Depth** | Hybrid search, reranking, structured prompting | Compare embedding providers, implement rerankers, context compression | Retrieval benchmark report, ingestion pipeline repo |
+| **3 — Agents & Workflow Engines** | Planner-executor, LangGraph, CrewAI, AutoGen | Implement orchestrated agent flow with guardrails and retries | Agent workflow demo, design decision log |
+| **4 — Evaluation & Observability** | Metrics, prompt regression, Langfuse/LangSmith, OpenTelemetry | Build eval datasets, automate regression suite, wire tracing dashboards | Evaluation dossier, cost/latency dashboard |
+| **5 — Governance & Safety** | Policy automation, privacy, model risk, incident response | Map governance controls into CI/CD, simulate incident response drill | Governance playbook, risk register, mitigation backlog |
+| **6 — Optimization & Executive Review** | Performance, cost, UX, stakeholder influence | Tune inference & caching, craft exec narrative, rehearse review | Final architecture doc, exec presentation, investment roadmap |
+
+## Rituals & Teaching Model
+- **Design reviews:** Weekly 60-minute review with peers/mentors. Use `15-workflows/pr-review.md` and `16-collaboration/design-review.md`.
+- **Deep work sprints:** Two 2-hour build blocks dedicated to labs. Pair in repos under `05-projects/`.
+- **Exec rehearsal:** Weeks 4–6 include stakeholder Q&A drills using `04-templates/executive-brief.md` and `16-collaboration/meeting-rituals.md`.
+
+## Tooling & Research Refresh
+- Track new model capabilities (GPT-4.1, Claude 3.5 Sonnet, Llama 3 405B, Mistral Large) and leverage [LiteLLM config](../06-toolchains/stack-reference.md) for provider swapping.
+- Compare orchestration frameworks (LangGraph, LlamaIndex agents, CrewAI, AutoGen, Fiddle) with emphasis on failure modes and logging.
+- Integrate observability via Langfuse, OpenTelemetry, Arize, Phoenix, or custom pipelines.
+- Evaluate with domain-specific datasets (HELM/HEIM, GSM8K, MMLU, and your proprietary corpora).
+
+## Assessment Rubric
+- **System Reliability (35%)** — Robustness under edge cases, retries, guardrails, fallback behaviour.
+- **Operational Excellence (25%)** — Depth of telemetry, alerts, governance automation, incident readiness.
+- **Value Articulation (20%)** — Clarity of cost/ROI analysis, stakeholder impact, roadmap.
+- **Story & Influence (20%)** — Quality of executive presentation, portfolio artifacts, community updates.
+
+## Graduation Pathways
+- Lead cross-functional adoption via the [AI CoE Bootcamp](bootcamp.md).
+- Spin up an internal or public-facing [Agentic Systems Lab](agentic-code-swarms.md) sprint.
+- Contribute new patterns or case studies to `01-design-patterns/` and `09-articles/`.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Lead the conversations, ship the systems, and operate responsibly. This open pla
 - **Creators & Educators.** Run workshops, newsletters, and community drops using the [Creator Launch Sequence](02-learning-paths/beginner.md) plus the [Brand Voice playbook](BRAND-VOICE.md).
 - **Professional Architects.** Join the six-week [Professional Studio](02-learning-paths/professional.md) to orchestrate multi-model systems with evaluation-first rigor.
 - **Enterprise & AI CoE Leaders.** Facilitate alignment with the revamped [Bootcamp](02-learning-paths/bootcamp.md), governance toolkits, and collaboration rituals.
-- **Agentic Innovators.** Layer in [Agentic Code Swarms](agentic-swarms/README.md), experiment with orchestrators, and publish learnings via the [Agentic SaaS Planner](05-projects/agentic-saas-planner.md).
+- **Agentic Innovators.** Layer in [Agentic Code Swarms](02-learning-paths/agentic-code-swarms.md), experiment with orchestrators, and publish learnings via the [Agentic SaaS Planner](05-projects/agentic-saas-planner.md).
 
 ## Operate with Confidence
 - **Evaluation stack:** [Metrics](07-evaluation/metrics.md), [Eval harness](07-evaluation/eval-harness.md), and [promptfoo integrations](05-projects/evals-langfuse.md).

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Lead the conversations, ship the systems, and operate responsibly. This open pla
 - **Clone the full operating system.** Pull the repo to unlock scripts, prompt packs, workflows, and design assets for your team and AI assistants.
 - **Tell a sharper story.** Use the [Brand Voice playbook](BRAND-VOICE.md) to stay on-message with executives, clients, and your audience.
 - **Ship and scale.** Pair enterprise-ready patterns with hands-on projects, eval workflows, and governance checklists.
+- **Level up the curriculum.** Follow the [Curriculum Architecture](02-learning-paths/curriculum-architecture.md) to move from the 100-hour sprint to executive bootcamps and agentic labs.
 
 ## Why Clone the Repository
 - **Offline & private workspaces.** Serve the site locally (`scripts/serve.sh`) and pair with your favourite AI copilots using the curated prompt packs in `prompt-packs/`.
@@ -48,15 +49,17 @@ Lead the conversations, ship the systems, and operate responsibly. This open pla
 - **Governance → Collaboration:** Stand up policy baselines, then drop the collaboration checklists into your team rituals.
 
 ## Start Your Journey (Choose the Lane that Fits)
-- **Launchpad (100 hours).** A curated sprint for builders who want traction fast — [100-Hour Plan](02-learning-paths/100-hour-ai-architect.md).
-- **Creators & Educators.** Translate the playbook into content with the [Beginner](02-learning-paths/beginner.md) and [Professional](02-learning-paths/professional.md) paths.
-- **Enterprise & AI CoE Leaders.** Run the [Bootcamp](02-learning-paths/bootcamp.md) to align architecture, governance, and adoption.
-- **Agentic Innovators.** Experiment with [Agentic Code Swarms](agentic-swarms/README.md) and the [Agentic SaaS Planner](05-projects/agentic-saas-planner.md).
+- **Launchpad (100 hours).** Sprint through foundations, retrieval, observability, and storytelling with the refreshed [100-Hour Plan](02-learning-paths/100-hour-ai-architect.md).
+- **Creators & Educators.** Run workshops, newsletters, and community drops using the [Creator Launch Sequence](02-learning-paths/beginner.md) plus the [Brand Voice playbook](BRAND-VOICE.md).
+- **Professional Architects.** Join the six-week [Professional Studio](02-learning-paths/professional.md) to orchestrate multi-model systems with evaluation-first rigor.
+- **Enterprise & AI CoE Leaders.** Facilitate alignment with the revamped [Bootcamp](02-learning-paths/bootcamp.md), governance toolkits, and collaboration rituals.
+- **Agentic Innovators.** Layer in [Agentic Code Swarms](agentic-swarms/README.md), experiment with orchestrators, and publish learnings via the [Agentic SaaS Planner](05-projects/agentic-saas-planner.md).
 
 ## Operate with Confidence
 - **Evaluation stack:** [Metrics](07-evaluation/metrics.md), [Eval harness](07-evaluation/eval-harness.md), and [promptfoo integrations](05-projects/evals-langfuse.md).
 - **Guardrails & governance:** [Privacy & GDPR](08-governance/privacy-gdpr.md), [Model risk](08-governance/model-risk.md), and policy templates.
 - **Tooling matrix:** [Stack reference](06-toolchains/stack-reference.md), [Cloud blueprints](docs/clouds.html), and [Platform comparisons](docs/platforms.html).
+- **Curriculum cadence:** Revisit the [Curriculum Architecture](02-learning-paths/curriculum-architecture.md) quarterly to plug in updated benchmarks, model releases, and sector case studies.
 
 ## Create Momentum for Your Brand & Community
 - Publish your progress using the [article outlines](09-articles/) and [content prompts](prompt-packs/).

--- a/README.org.md
+++ b/README.org.md
@@ -51,7 +51,7 @@ Lead the conversations, ship the systems, and operate responsibly. This open pla
 - **Launchpad (100 hours).** A curated sprint for builders who want traction fast — [100-Hour Plan](02-learning-paths/100-hour-ai-architect.md).
 - **Creators & Educators.** Translate the playbook into content with the [Beginner](02-learning-paths/beginner.md) and [Professional](02-learning-paths/professional.md) paths.
 - **Enterprise & AI CoE Leaders.** Run the [Bootcamp](02-learning-paths/bootcamp.md) to align architecture, governance, and adoption.
-- **Agentic Innovators.** Experiment with [Agentic Code Swarms](agentic-swarms/README.md) and the [Agentic SaaS Planner](05-projects/agentic-saas-planner.md).
+- **Agentic Innovators.** Experiment with [Agentic Code Swarms](02-learning-paths/agentic-code-swarms.md) and the [Agentic SaaS Planner](05-projects/agentic-saas-planner.md).
 
 ## Operate with Confidence
 - **Evaluation stack:** [Metrics](07-evaluation/metrics.md), [Eval harness](07-evaluation/eval-harness.md), and [promptfoo integrations](05-projects/evals-langfuse.md).

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -1,55 +1,46 @@
 # Start Here — Build Your AI Architect Command Center
 
-You’re here because you want to ship real AI value, guide stakeholders with confidence, and make your work easy to share. This quick guide orients you to the full experience so you can get momentum within minutes.
+You’re here to ship real AI value, guide stakeholders with confidence, and show your work. This quickstart orients you to the refreshed curriculum so you can choose the right lane, lock in your learning rhythm, and publish proof every week.
 
-## 1. Choose Your Mission Profile
+## 1. Map Your Learning Spine
+| Program Layer | Best For | Outcomes | Go-To Assets |
+| --- | --- | --- | --- |
+| **Launchpad — 100 Hours** | Builders who need momentum fast | Retrieval pipeline with eval harness, architecture brief, stakeholder recap | [100-Hour Plan](02-learning-paths/100-hour-ai-architect.md), [Design Patterns](01-design-patterns/), [RAG on Supabase](05-projects/rag-on-supabase.md) |
+| **Creator Launch Sequence** | Educators, creators, advocates | Workshops, newsletters, and explainer content anchored in safe prompting and governance | [Beginner Path](02-learning-paths/beginner.md), [Brand Voice](BRAND-VOICE.md), [Article Outlines](09-articles/) |
+| **Professional Architect Studio** | Staff/principal ICs, AI product leads | Multi-model system design, observability rollout, executive reviews | [Professional Path](02-learning-paths/professional.md), [Observability Playbook](15-workflows/observability-playbook.md), [Eval Harness](05-projects/evals-langfuse.md) |
+| **AI CoE Bootcamp** | Platform leaders, transformation teams | Governance baseline, platform roadmap, adoption plan | [Bootcamp](02-learning-paths/bootcamp.md), [Governance Toolkit](08-governance/), [Collaboration Rituals](16-collaboration/) |
+| **Agentic Systems Lab** | Advanced builders, R&D squads | Agent orchestration with tracing, guardrails, and UX | [Agentic Code Swarms](02-learning-paths/agentic-code-swarms.md), [Agentic SaaS Planner](05-projects/agentic-saas-planner.md) |
 
-### Launchpad — First 100 Hours
-- Follow the [100-Hour AI Architect plan](02-learning-paths/100-hour-ai-architect.md) to sprint through foundations, shipping, and storytelling.
-- Pair the plan with three anchor projects: [RAG on Supabase](05-projects/rag-on-supabase.md), [Langfuse evals](05-projects/evals-langfuse.md), and [Vector search benchmarks](05-projects/vector-search-pgvector.md).
+Need the full rationale behind each layer? Read the [Curriculum Architecture](02-learning-paths/curriculum-architecture.md).
 
-### Creator & Influencer Track
-- Use the [Beginner](02-learning-paths/beginner.md) and [Professional](02-learning-paths/professional.md) paths to pace long-form content, workshops, and community sessions.
-- Pull examples and citations from the [Awesome collections](03-awesome/) and [Articles](09-articles/) folders.
+## 2. Run the Weekly Value Loop
+1. **Discover the stakeholder need.** Use the discovery questions packaged with each [design pattern](01-design-patterns/). Capture risks, KPIs, and constraints in a one-page brief.
+2. **Build the smallest valuable slice.** Follow the hands-on sections inside the relevant [project guides](05-projects/). Prioritise retrieval quality, latency, and safe prompting.
+3. **Measure with live telemetry.** Instrument metrics from day one with [Langfuse evals](05-projects/evals-langfuse.md), `promptfoo`, or your preferred harness. Log token/latency/cost in the [observability workflow](15-workflows/observability-playbook.md).
+4. **Govern & document decisions.** Align with the [privacy](08-governance/privacy-gdpr.md) and [model risk](08-governance/model-risk.md) templates. Track mitigations and sign-offs in `16-collaboration/` rituals.
+5. **Share the story.** Publish a recap using [article outlines](09-articles/) or the [executive brief template](04-templates/executive-brief.md). Drop demos into the [Projects catalog](docs/projects.html).
 
-### Enterprise & AI CoE Leadership
-- Run the [Bootcamp](02-learning-paths/bootcamp.md) to align product, platform, risk, and ops teams.
-- Combine architecture patterns (`01-design-patterns/`) with the [Governance toolkit](08-governance/) and [Collaboration playbooks](16-collaboration/) for executive visibility.
+## 3. How We Teach
+- **Blended cadence.** Each program pairs 30–45 minute async primers with live 90-minute build labs. Labs use mob-building, tracing walk-throughs, and peer critiques to keep everyone shipping.
+- **Systems thinking first.** We emphasise retrieval, agents, and evaluation as a single loop. Every lab references the same core metrics, governance checklists, and storytelling prompts.
+- **Latest intelligence.** Tooling recommendations include GPT-4.1, Claude 3.5 Sonnet, Llama 3, Mistral Large, LangGraph, CrewAI, LlamaIndex, LiteLLM, pgvector/Weaviate, Langfuse, and OpenTelemetry. All modules stay vendor-agnostic so you can swap stacks quickly.
+- **Proof over theory.** Expect to submit code repos, Langfuse dashboards, guardrail policies, and executive-ready narratives. Rubrics live in `15-workflows/` and emphasise functionality, clarity, governance, and influence.
 
-### Advisors, Clients, Friends & Family
-- Share the [Experience page](docs/experience.html) when introducing the hub to new collaborators.
-- Use `04-templates/` to spin up proposals, meeting notes, and recap reports fast.
+## 4. Assessments & Portfolio
+- **Weekly checkpoints.** Finish each sprint with a demo recording, eval metrics table, and a short retrospective that highlights trade-offs.
+- **Flagship deliverables.** Combine architecture diagrams, cost models, risk registers, and storytelling assets into a portfolio that wins stakeholder trust.
+- **Signals & sharing.** Add your artifacts to `example-sessions/` or drop them into a cohort channel. Highlight lessons learned so the community compounds knowledge.
 
-## 2. Map Your Architecture Playbook
-- Start with three core patterns: [Content Generation](01-design-patterns/content-generation.md), [Decision Support](01-design-patterns/decision-support.md), and [Model Lifecycle Management](01-design-patterns/model-lifecycle-management.md).
-- Explore the [Concept decks](12-concepts/) for mental models (retrieval, evaluation, observability, safety) you can present to stakeholders.
-- Browse [Platforms](docs/platforms.html) and [Cloud blueprints](docs/clouds.html) to match vendor capabilities with your constraints.
+## 5. Set Up Your Workspace
+1. Clone the repo: `git clone https://github.com/AI-Architect-Academy/ai-architect-academy.git`
+2. Serve the site locally: `scripts/serve.sh` → http://localhost:8080 for the full experience hub.
+3. Install dependencies once: `npm install`
+4. Regenerate search as you add content: `npm run build:index`
+5. Capture refreshed screenshots: `node scripts/capture-screenshots.mjs`
+6. Tailor prompts, templates, and workflows inside `prompt-packs/` and `15-workflows/` for your team.
 
-## 3. Build Value Loops
-Focus on tight feedback loops that demonstrate value quickly:
-- **Discovery → Pattern:** Interview stakeholders using the discovery questions in each pattern; summarise risks and value as a one-page brief.
-- **Data → Retrieval → Feedback:** Follow [RAG on Supabase](05-projects/rag-on-supabase.md), add reranking from the [Toolchains reference](06-toolchains/stack-reference.md), and monitor citations.
-- **Agents & Automation:** Use [Agentic Code Swarms](agentic-swarms/README.md) for multi-agent experiments, or the [Agentic SaaS Planner](05-projects/agentic-saas-planner.md) for product discovery.
-- **Evaluation First:** Instrument with [metrics](07-evaluation/metrics.md), [promptfoo harnesses](05-projects/evals-langfuse.md), and [observability workflows](15-workflows/observability-playbook.md) before scaling access.
-
-## 4. Instrument, Govern, and Operate
-- Establish guardrails with [Privacy & GDPR](08-governance/privacy-gdpr.md), [Model Risk](08-governance/model-risk.md), and the [Governance checklists](08-governance/checklists.md).
-- Monitor costs, latency, and regressions using [Langfuse traces](05-projects/evals-langfuse.md) plus the [Topics](docs/topics/index.html) deep dives on observability and guardrails.
-- Document team rituals with [Pairing workflows](15-workflows/pairing.md), [PR review guides](15-workflows/pr-review.md), and the [AI collaboration playbook](16-collaboration/working-with-ai.md).
-
-## 5. Amplify and Share the Story
-- Draft updates using [article outlines](09-articles/) and the [Brand Voice guide](BRAND-VOICE.md) to stay consistent across newsletters, talks, and executive briefings.
-- Curate demos with the [Projects catalog](docs/projects.html) and capture new screenshots using `node scripts/capture-screenshots.mjs`.
-- Promote trusted resources to your community via the [Resources hub](docs/resources.html) and [Topics quick wins](docs/topics/index.html).
-
-## Clone & Personalise the Repo
-1. `git clone https://github.com/AI-Architect-Academy/ai-architect-academy.git`
-2. `scripts/serve.sh` to explore the site locally at http://localhost:8080
-3. Update or add SVGs/PNGs under `assets/` and `docs/assets/`
-4. Run `npm install` once, then `npm run build:index` whenever you add new content so search stays sharp.
-5. Tailor prompts, templates, and workflows inside `prompt-packs/` and `15-workflows/` for your team.
-
-## Keep Exploring
+## 6. Keep Exploring
 - Tour the full [Experience guide](docs/experience.html) for persona-specific journeys and navigation tips.
 - Dive into the [Sitemap](docs/sitemap.xml) or use [Search](docs/search.html) to surface patterns, projects, and governance assets instantly.
-- Track platform progress and upcoming drops in the refreshed [Roadmap](00-roadmap/ROADMAP.md).
+- Track platform progress and upcoming drops in the [Roadmap](00-roadmap/ROADMAP.md).
+- Propose upgrades via issues or PRs, and cite the [Curriculum Architecture](02-learning-paths/curriculum-architecture.md) so we keep the system coherent.

--- a/docs/data/search-index.json
+++ b/docs/data/search-index.json
@@ -416,18 +416,46 @@
   },
   {
     "id": "02-learning-paths/100-hour-ai-architect.md",
-    "title": "100‑Hour AI Architect Plan",
+    "title": "100‑Hour AI Architect Plan — Launchpad Sprint",
     "href": "https://github.com/AI-Architect-Academy/ai-architect-academy/blob/main/02-learning-paths/100-hour-ai-architect.md",
     "section": "Learning Paths",
     "path": "02-learning-paths/100-hour-ai-architect.md",
     "headings": [
       {
         "level": 1,
-        "text": "100‑Hour AI Architect Plan"
+        "text": "100‑Hour AI Architect Plan — Launchpad Sprint"
+      },
+      {
+        "level": 2,
+        "text": "Program Outcomes"
+      },
+      {
+        "level": 2,
+        "text": "Weekly Breakdown"
+      },
+      {
+        "level": 2,
+        "text": "Daily Cadence"
+      },
+      {
+        "level": 2,
+        "text": "Deliverables & Rubrics"
+      },
+      {
+        "level": 2,
+        "text": "Recommended Toolchain"
+      },
+      {
+        "level": 2,
+        "text": "Suggested Reading & Research"
+      },
+      {
+        "level": 2,
+        "text": "Next Steps After Launchpad"
       }
     ],
-    "excerpt": "# 100‑Hour AI Architect Plan Format: 4 weeks × ~25 hours/week. Focus on shipping real artifacts weekly. Week 1 — Foundations (25h) - LLM basics (6h): tokenization, attention, prompting - Retrieval & embeddings (8h): chunking, hybrid search, pgvector - Hands‑on (8h): implement vector search; small RAG demo - Assessment ",
-    "content": "# 100‑Hour AI Architect Plan Format: 4 weeks × ~25 hours/week. Focus on shipping real artifacts weekly. Week 1 — Foundations (25h) - LLM basics (6h): tokenization, attention, prompting - Retrieval & embeddings (8h): chunking, hybrid search, pgvector - Hands‑on (8h): implement vector search; small RAG demo - Assessment (3h): quiz + short write‑up Week 2 — Systems (25h) - Agents & tools (6h): function calling, orchestration - Observability & evals (6h): Langfuse, metrics, datasets - Hands‑on (10h): RAG with citations and eval harness - Assessment (3h): demo + reflection Week 3 — Governance & Performance (25h) - Privacy/GDPR (4h), model risk (4h) - Performance & cost (6h): caching, batch, smaller models - Hands‑on (8h): optimize RAG; add guardrails - Assessment (3h): doc architecture & SLOs Week 4 — Specialization & Portfolio (25h) - Industry pattern (6h): choose domain - Project (15h): complete end‑to‑end PoC - Presentation (4h): writeup + slides + video Deliverables - Working RAG app with citations - Eval report with metrics - Architecture doc (diagram, SLOs, costs) - Final presentation"
+    "excerpt": "# 100‑Hour AI Architect Plan — Launchpad Sprint Format: 4 weeks × ~25 hours/week. Blend async deep dives (12h), guided labs (8h), and reflection/storytelling (5h). ## Program Outcomes - Ship a production-grade retrieval pipeline (ingestion → hybrid search → rerank → answer) with citations. - Instrument evaluation and o",
+    "content": "# 100‑Hour AI Architect Plan — Launchpad Sprint Format: 4 weeks × ~25 hours/week. Blend async deep dives (12h), guided labs (8h), and reflection/storytelling (5h). ## Program Outcomes - Ship a production-grade retrieval pipeline (ingestion → hybrid search → rerank → answer) with citations. - Instrument evaluation and observability from day one (Langfuse or OSS equivalent, prompt regression tests, cost/latency dashboards). - Document architecture, governance decisions, and value narrative that convinces stakeholders to scale. ## Weekly Breakdown | Week | Focus | Key Work | Time Split | | --- | --- | --- | --- | | **Week 1 — Foundations & Retrieval** | Tokenization, attention, prompting systems, embedding strategy | Build dataset ingestion notebook, compare embedding models, implement pgvector hybrid search | 6h theory · 6h lab · 4h reading · 3h reflection · 6h optional dojo | | **Week 2 — Systems & Agents** | Tool use, function calling, orchestration strategies, context windows | Extend RAG app with tool-enabled agent, implement reranking, add streaming UX | 5h theory · 8h lab · 4h pairing · 4h research · 4h reflection | | **Week 3 — Evaluation, Observability & Governance** | Metrics, eval harnesses, tracing, privacy, model risk | Wire Langfuse traces, run prompt regression suite, map privacy controls, create incident playbook | 5h theory · 8h lab · 5h ops reviews · 3h governance · 4h storytelling | | **Week 4 — Specialisation & Portfolio** | Industry deep dives, optimisation, stakeholder influence | Optimise latency/cost, integrate guardrails, produce architecture brief, record final demo | 4h theory · 9h lab · 4h stakeholder interviews · 4h storytelling · 4h retros | ## Daily Cadence - **Mon:** 90-minute async module + guided exercise (LLM fundamentals, retrieval research, architecture patterns). - **Tue:** Live lab (mob build) on ingestion, retrieval, or orchestration. Pair using the [vector search project](../05-projects/vector-search-pgvector.md). - **Wed:** Eva"
   },
   {
     "id": "02-learning-paths/agentic-code-swarms.md",
@@ -439,6 +467,10 @@
       {
         "level": 1,
         "text": "Learning Path: Agentic Code Swarms"
+      },
+      {
+        "level": 2,
+        "text": "Curriculum Placement"
       },
       {
         "level": 2,
@@ -465,53 +497,160 @@
         "text": "Grading Rubric"
       }
     ],
-    "excerpt": "# Learning Path: Agentic Code Swarms Audience: AI Architects and Builders using Codex, Claude Code, or Cursor. Outcome: Ship a working multi-agent swarm, understand orchestration patterns, and build a visual explorer. Time: 10–16 hours (self-paced) ## Prereqs - Python 3.11 - Optional: OpenAI/Anthropic key (LiteLLM). Ot",
-    "content": "# Learning Path: Agentic Code Swarms Audience: AI Architects and Builders using Codex, Claude Code, or Cursor. Outcome: Ship a working multi-agent swarm, understand orchestration patterns, and build a visual explorer. Time: 10–16 hours (self-paced) ## Prereqs - Python 3.11 - Optional: OpenAI/Anthropic key (LiteLLM). Otherwise runs offline. ## Modules 1) Concepts and Patterns (1h) - Roles, messages, tools, orchestrators - Coordination: sequential, round-robin, planner–worker–reviewer 2) Core Setup (1h) - , venv, run Hello Swarm 3) Orchestration (2h) - Inspect and extend P–W–R with retries and critiques 4) Tools (2h) - Add a and tool 5) Visual Explorer (2h) - Use , add controls and message tracing 6) SaaS Planner (2–4h) - Extend to output a BoM and architecture diagram 7) Evaluate (2h) - Design acceptance checks and simple evals (see ) ## Hands-On Steps ## Challenges - Add a agent that blocks the final answer if tests fail - Add tracing to show token usage per agent (mock values offline) - Swap providers (OpenAI ↔ Anthropic) via LiteLLM config only ## Deliverables - Working swarm with at least 3 roles - A recorded screen demo of the Streamlit explorer - A short doc: architecture, trade-offs, and next steps ## Grading Rubric - Functionality (40%): agents coordinate, produce coherent outputs - Clarity (30%): code readability, clear prompts, thoughtful defaults - UX (20%): UI communicates roles, history, and decisions visually - Rigor (10%): eval checks or tests"
+    "excerpt": "# Learning Path: Agentic Code Swarms Audience: AI Architects and Builders using Codex, Claude Code, Cursor, or other pair-programming copilots. Outcome: Ship a working multi-agent swarm, understand orchestration patterns, and build a visual explorer with live telemetry. Time: 10–16 hours (self-paced) This lab is the ca",
+    "content": "# Learning Path: Agentic Code Swarms Audience: AI Architects and Builders using Codex, Claude Code, Cursor, or other pair-programming copilots. Outcome: Ship a working multi-agent swarm, understand orchestration patterns, and build a visual explorer with live telemetry. Time: 10–16 hours (self-paced) This lab is the capstone inside the [Agentic Systems Lab](curriculum-architecture.md#program-layers--flagship-outcomes). Pair it with the [Professional Studio](professional.md) for evaluation depth and the [Bootcamp](bootcamp.md) to socialise operating models with leadership. ## Curriculum Placement - **Prerequisite:** Comfortable with the [100-Hour Launchpad](100-hour-ai-architect.md) retrieval pipeline and evaluation loop. - **Parallel tracks:** Join weekly design reviews with Professional Studio cohorts to compare orchestrator decisions and failure modes. - **Post-lab moves:** Publish your swarm pattern as a case study in or demo it during a bootcamp executive council. ## Prereqs - Python 3.11 - Optional: OpenAI/Anthropic key (LiteLLM). Otherwise runs offline. ## Modules 1) Concepts and Patterns (1h) - Roles, messages, tools, orchestrators - Coordination: sequential, round-robin, planner–worker–reviewer 2) Core Setup (1h) - , venv, run Hello Swarm 3) Orchestration (2h) - Inspect and extend P–W–R with retries and critiques 4) Tools (2h) - Add a and tool 5) Visual Explorer (2h) - Use , add controls and message tracing 6) SaaS Planner (2–4h) - Extend to output a BoM and architecture diagram 7) Evaluate (2h) - Design acceptance checks and simple evals (see ) ## Hands-On Steps ## Challenges - Add a agent that blocks the final answer if tests fail - Add tracing to show token usage per agent (mock values offline) - Swap providers (OpenAI ↔ Anthropic) via LiteLLM config only ## Deliverables - Working swarm with at least 3 roles - A recorded screen demo of the Streamlit explorer - A short doc: architecture, trade-offs, and next steps ## Grading Rubric - Functionality (40%): a"
   },
   {
     "id": "02-learning-paths/beginner.md",
-    "title": "Beginner Path (4 Weeks)",
+    "title": "Beginner Path — Creator Launch Sequence (4 Weeks)",
     "href": "https://github.com/AI-Architect-Academy/ai-architect-academy/blob/main/02-learning-paths/beginner.md",
     "section": "Learning Paths",
     "path": "02-learning-paths/beginner.md",
     "headings": [
       {
         "level": 1,
-        "text": "Beginner Path (4 Weeks)"
+        "text": "Beginner Path — Creator Launch Sequence (4 Weeks)"
+      },
+      {
+        "level": 2,
+        "text": "Outcomes"
+      },
+      {
+        "level": 2,
+        "text": "Weekly Flow"
+      },
+      {
+        "level": 2,
+        "text": "Teaching Model"
+      },
+      {
+        "level": 2,
+        "text": "Portfolio Checklist"
+      },
+      {
+        "level": 2,
+        "text": "Next Moves"
       }
     ],
-    "excerpt": "# Beginner Path (4 Weeks) - Week 1: LLM basics, prompting, safety - Week 2: Retrieval & embeddings, pgvector - Week 3: Agents & tools, orchestration - Week 4: Evaluation & observability",
-    "content": "# Beginner Path (4 Weeks) - Week 1: LLM basics, prompting, safety - Week 2: Retrieval & embeddings, pgvector - Week 3: Agents & tools, orchestration - Week 4: Evaluation & observability"
+    "excerpt": "# Beginner Path — Creator Launch Sequence (4 Weeks) Designed for creators, educators, and advocates who want to teach AI architecture responsibly. Expect ~8–10 hours per week across async study, micro-builds, and storytelling. ## Outcomes - Explain core AI architecture concepts with clarity (retrieval, agents, evaluati",
+    "content": "# Beginner Path — Creator Launch Sequence (4 Weeks) Designed for creators, educators, and advocates who want to teach AI architecture responsibly. Expect ~8–10 hours per week across async study, micro-builds, and storytelling. ## Outcomes - Explain core AI architecture concepts with clarity (retrieval, agents, evaluation, governance). - Facilitate workshops or community sessions that demonstrate safe prompting and responsible usage. - Publish at least three artifacts (newsletter, tutorial, talk track) aligned with the Brand Voice playbook. ## Weekly Flow | Week | Focus | Key Activities | Teaching Assets | | --- | --- | --- | --- | | **Week 1 — Narrative Foundations** | Positioning, personas, value loops | Study [START-HERE](../START-HERE.md), craft audience personas, map value loop storyboard, draft welcome newsletter | [Brand Voice](../BRAND-VOICE.md), [Experience guide](../docs/experience.html) | | **Week 2 — Retrieval & Prompt Craft** | Prompt design, retrieval mental models, safe defaults | Run mini RAG lab using [vector search](../05-projects/vector-search-pgvector.md), capture screenshots, create cheat sheet | [Design Patterns](../01-design-patterns/), [Resources hub](../10-resources/) | | **Week 3 — Governance & Trust Signals** | Privacy, risk, evaluation narratives | Summarise [privacy](../08-governance/privacy-gdpr.md) & [model risk](../08-governance/model-risk.md) into workshop slides, design \"trust checklist\" handout | [Governance checklists](../08-governance/checklists.md), [Metrics](../07-evaluation/metrics.md) | | **Week 4 — Launch & Amplify** | Community delivery, storytelling, feedback loops | Host a live session or recorded tutorial, publish recap article, solicit feedback for iteration | [Article outlines](../09-articles/), [Collaboration playbook](../16-collaboration/working-with-ai.md) | ## Teaching Model - **Micro-drops.** 20-minute videos or async primers paired with practice prompts so learners can teach the content immediately. - **Office hou"
   },
   {
     "id": "02-learning-paths/bootcamp.md",
-    "title": "Bootcamp Path (AI CoE Inspired)",
+    "title": "Bootcamp Path — AI Center of Excellence Alignment",
     "href": "https://github.com/AI-Architect-Academy/ai-architect-academy/blob/main/02-learning-paths/bootcamp.md",
     "section": "Learning Paths",
     "path": "02-learning-paths/bootcamp.md",
     "headings": [
       {
         "level": 1,
-        "text": "Bootcamp Path (AI CoE Inspired)"
+        "text": "Bootcamp Path — AI Center of Excellence Alignment"
+      },
+      {
+        "level": 2,
+        "text": "Bootcamp Outcomes"
+      },
+      {
+        "level": 2,
+        "text": "Weekly Agenda"
+      },
+      {
+        "level": 2,
+        "text": "Daily Rhythm (per week)"
+      },
+      {
+        "level": 2,
+        "text": "Toolkits & References"
+      },
+      {
+        "level": 2,
+        "text": "Assessment & Success Signals"
+      },
+      {
+        "level": 2,
+        "text": "Post-Bootcamp Actions"
       }
     ],
-    "excerpt": "# Bootcamp Path (AI CoE Inspired) - Week 1: Core patterns & CX - Week 2: Architecture, vector search, integration, performance, governance - Week 3: Industry, agents, PoC & presentation",
-    "content": "# Bootcamp Path (AI CoE Inspired) - Week 1: Core patterns & CX - Week 2: Architecture, vector search, integration, performance, governance - Week 3: Industry, agents, PoC & presentation"
+    "excerpt": "# Bootcamp Path — AI Center of Excellence Alignment Three intensive weeks for heads of AI, platform leaders, and cross-functional squads. Designed to align roadmap, governance, budget, and talent around measurable outcomes. Plan for 12–14 hours per week plus two executive councils. ## Bootcamp Outcomes - Shared AI oper",
+    "content": "# Bootcamp Path — AI Center of Excellence Alignment Three intensive weeks for heads of AI, platform leaders, and cross-functional squads. Designed to align roadmap, governance, budget, and talent around measurable outcomes. Plan for 12–14 hours per week plus two executive councils. ## Bootcamp Outcomes - Shared AI operating model (vision, value loops, operating cadence) grounded in current capabilities and risk appetite. - Platform architecture decision with vendor comparison, cost/latency forecasts, and integration backlog. - Governance baseline covering privacy, security, compliance, incident response, and responsible AI commitments. ## Weekly Agenda | Week | Council & Focus | Key Sessions | Artefacts | | --- | --- | --- | --- | | **Week 1 — Diagnose & Frame** | Council: product + exec sponsors | Experience walkthrough, stakeholder interviews, capability mapping, risk heatmap | Vision brief, capability matrix, stakeholder map | | **Week 2 — Architect & Decide** | Council: platform + engineering leads | Platform matrix review, retrieval & agent demos, cost modelling, integration sequencing | Platform scorecard, integration backlog, budget plan | | **Week 3 — Govern & Launch** | Council: legal, compliance, data, security | Policy workshops, incident tabletop, measurement framework, communications plan | Governance playbook, KPI dashboard draft, rollout narrative | ## Daily Rhythm (per week) - **Day 1:** 90-minute briefing (experience map, roadmap, best-in-class benchmarks) followed by executive working session. - **Day 2:** Technical deep dive — review architecture options, integration requirements, security posture. - **Day 3:** Governance workshop using templates plus risk scenario drills. - **Day 4:** Metrics & evaluation clinic leveraging [metrics](../07-evaluation/metrics.md), harnesses, and Langfuse dashboards. - **Day 5:** Story & alignment — craft executive update, Q&A rehearsal, and action plan. ## Toolkits & References - **Strategy:** [Roadmap](../00-roadm"
+  },
+  {
+    "id": "02-learning-paths/curriculum-architecture.md",
+    "title": "AI Architect Curriculum Architecture",
+    "href": "https://github.com/AI-Architect-Academy/ai-architect-academy/blob/main/02-learning-paths/curriculum-architecture.md",
+    "section": "Learning Paths",
+    "path": "02-learning-paths/curriculum-architecture.md",
+    "headings": [
+      {
+        "level": 1,
+        "text": "AI Architect Curriculum Architecture"
+      },
+      {
+        "level": 2,
+        "text": "Program Layers & Flagship Outcomes"
+      },
+      {
+        "level": 2,
+        "text": "Learning Rhythms & Teaching Model"
+      },
+      {
+        "level": 2,
+        "text": "Curriculum Pillars & Depth"
+      },
+      {
+        "level": 2,
+        "text": "Feedback, Assessment, and Credentialing"
+      },
+      {
+        "level": 2,
+        "text": "Continuous Research & Refresh Cycle"
+      },
+      {
+        "level": 2,
+        "text": "How to Use This Map"
+      }
+    ],
+    "excerpt": "# AI Architect Curriculum Architecture Design the most capable AI architects on the planet. This map shows how every learner moves from foundations to executive-level influence with clear feedback loops, live build labs, and evergreen research refreshes. ## Program Layers & Flagship Outcomes | Layer | Duration & Cadenc",
+    "content": "# AI Architect Curriculum Architecture Design the most capable AI architects on the planet. This map shows how every learner moves from foundations to executive-level influence with clear feedback loops, live build labs, and evergreen research refreshes. ## Program Layers & Flagship Outcomes | Layer | Duration & Cadence | Primary Persona | Focus & Flagship Deliverables | Core Assets | | --- | --- | --- | --- | --- | | **Launchpad — 100-Hour Architect Sprint** | 4 weeks · 25 h/week · mix of async lessons + 2 live labs | Hands-on builders, technical founders | Ship a production-ready retrieval pipeline with eval harness, instrument costs, publish an architecture brief | [100-hour AI Architect](100-hour-ai-architect.md), [RAG on Supabase](../05-projects/rag-on-supabase.md), [Eval Harness](../05-projects/evals-langfuse.md) | | **Creator Launch Sequence** | 4 weeks · 8–10 h/week · cohort-friendly | Creators, community leads, educators | Translate key concepts into workshops, articles, and explainer assets while demonstrating safe prompting patterns | [Beginner Path](beginner.md), [Article Outlines](../09-articles/), [Brand Voice](../BRAND-VOICE.md) | | **Professional Architect Studio** | 6 weeks · 12–15 h/week · weekly design reviews | Staff/principal architects, AI product leads | Orchestrate multi-model systems, deploy eval+observability stack, defend trade-offs in exec review | [Professional Path](professional.md), [Design Patterns](../01-design-patterns/), [Observability Playbook](../15-workflows/observability-playbook.md) | | **AI CoE Bootcamp** | 3 intensive weeks · 2 executive councils/week | Heads of AI, platform leaders, cross-functional squads | Align roadmap, governance, and platform choices; produce a board-ready adoption plan | [Bootcamp Path](bootcamp.md), [Governance Toolkit](../08-governance/), [Collaboration Rituals](../16-collaboration/) | | **Agentic Systems Lab** | 2–4 week studio · blended async + live swarm critiques | Applied researchers, advanced "
   },
   {
     "id": "02-learning-paths/professional.md",
-    "title": "Professional Path (6 Weeks)",
+    "title": "Professional Path — Architect Studio (6 Weeks)",
     "href": "https://github.com/AI-Architect-Academy/ai-architect-academy/blob/main/02-learning-paths/professional.md",
     "section": "Learning Paths",
     "path": "02-learning-paths/professional.md",
     "headings": [
       {
         "level": 1,
-        "text": "Professional Path (6 Weeks)"
+        "text": "Professional Path — Architect Studio (6 Weeks)"
+      },
+      {
+        "level": 2,
+        "text": "Outcomes"
+      },
+      {
+        "level": 2,
+        "text": "Weekly Blueprint"
+      },
+      {
+        "level": 2,
+        "text": "Rituals & Teaching Model"
+      },
+      {
+        "level": 2,
+        "text": "Tooling & Research Refresh"
+      },
+      {
+        "level": 2,
+        "text": "Assessment Rubric"
+      },
+      {
+        "level": 2,
+        "text": "Graduation Pathways"
       }
     ],
-    "excerpt": "# Professional Path (6 Weeks) - Foundations → Systems → Governance → Specialization - Projects: RAG on Supabase, Eval harness, Agentic workflow",
-    "content": "# Professional Path (6 Weeks) - Foundations → Systems → Governance → Specialization - Projects: RAG on Supabase, Eval harness, Agentic workflow"
+    "excerpt": "# Professional Path — Architect Studio (6 Weeks) For staff/principal architects, AI product leads, and senior builders who need to orchestrate reliable, multi-model systems. Expect 12–15 hours per week with weekly design reviews and exec-facing presentations. ## Outcomes - Design and deploy end-to-end architectures tha",
+    "content": "# Professional Path — Architect Studio (6 Weeks) For staff/principal architects, AI product leads, and senior builders who need to orchestrate reliable, multi-model systems. Expect 12–15 hours per week with weekly design reviews and exec-facing presentations. ## Outcomes - Design and deploy end-to-end architectures that combine retrieval, tool-enabled agents, and domain-specific adapters. - Operationalise evaluation, observability, and governance with measurable SLOs and incident playbooks. - Influence stakeholders using quantified trade-offs, cost models, and portfolio-ready narratives. ## Weekly Blueprint | Week | Theme | Systems Focus | Labs & Deliverables | | --- | --- | --- | --- | | **1 — Discovery & Patterns** | Align on business goals, value loops, and risk posture | Pattern selection, capability map, stakeholder interviews | Discovery brief, architecture hypothesis, stakeholder playback | | **2 — Retrieval Depth** | Hybrid search, reranking, structured prompting | Compare embedding providers, implement rerankers, context compression | Retrieval benchmark report, ingestion pipeline repo | | **3 — Agents & Workflow Engines** | Planner-executor, LangGraph, CrewAI, AutoGen | Implement orchestrated agent flow with guardrails and retries | Agent workflow demo, design decision log | | **4 — Evaluation & Observability** | Metrics, prompt regression, Langfuse/LangSmith, OpenTelemetry | Build eval datasets, automate regression suite, wire tracing dashboards | Evaluation dossier, cost/latency dashboard | | **5 — Governance & Safety** | Policy automation, privacy, model risk, incident response | Map governance controls into CI/CD, simulate incident response drill | Governance playbook, risk register, mitigation backlog | | **6 — Optimization & Executive Review** | Performance, cost, UX, stakeholder influence | Tune inference & caching, craft exec narrative, rehearse review | Final architecture doc, exec presentation, investment roadmap | ## Rituals & Teaching Model - *"
   },
   {
     "id": "03-awesome/awesome-agents.md",
@@ -1679,50 +1818,30 @@
       },
       {
         "level": 2,
-        "text": "1. Choose Your Mission Profile"
-      },
-      {
-        "level": 3,
-        "text": "Launchpad — First 100 Hours"
-      },
-      {
-        "level": 3,
-        "text": "Creator & Influencer Track"
-      },
-      {
-        "level": 3,
-        "text": "Enterprise & AI CoE Leadership"
-      },
-      {
-        "level": 3,
-        "text": "Advisors, Clients, Friends & Family"
+        "text": "1. Map Your Learning Spine"
       },
       {
         "level": 2,
-        "text": "2. Map Your Architecture Playbook"
+        "text": "2. Run the Weekly Value Loop"
       },
       {
         "level": 2,
-        "text": "3. Build Value Loops"
+        "text": "3. How We Teach"
       },
       {
         "level": 2,
-        "text": "4. Instrument, Govern, and Operate"
+        "text": "4. Assessments & Portfolio"
       },
       {
         "level": 2,
-        "text": "5. Amplify and Share the Story"
+        "text": "5. Set Up Your Workspace"
       },
       {
         "level": 2,
-        "text": "Clone & Personalise the Repo"
-      },
-      {
-        "level": 2,
-        "text": "Keep Exploring"
+        "text": "6. Keep Exploring"
       }
     ],
-    "excerpt": "# Start Here — Build Your AI Architect Command Center You’re here because you want to ship real AI value, guide stakeholders with confidence, and make your work easy to share. This quick guide orients you to the full experience so you can get momentum within minutes. ## 1. Choose Your Mission Profile ### Launchpad — Fi",
-    "content": "# Start Here — Build Your AI Architect Command Center You’re here because you want to ship real AI value, guide stakeholders with confidence, and make your work easy to share. This quick guide orients you to the full experience so you can get momentum within minutes. ## 1. Choose Your Mission Profile ### Launchpad — First 100 Hours - Follow the [100-Hour AI Architect plan](02-learning-paths/100-hour-ai-architect.md) to sprint through foundations, shipping, and storytelling. - Pair the plan with three anchor projects: [RAG on Supabase](05-projects/rag-on-supabase.md), [Langfuse evals](05-projects/evals-langfuse.md), and [Vector search benchmarks](05-projects/vector-search-pgvector.md). ### Creator & Influencer Track - Use the [Beginner](02-learning-paths/beginner.md) and [Professional](02-learning-paths/professional.md) paths to pace long-form content, workshops, and community sessions. - Pull examples and citations from the [Awesome collections](03-awesome/) and [Articles](09-articles/) folders. ### Enterprise & AI CoE Leadership - Run the [Bootcamp](02-learning-paths/bootcamp.md) to align product, platform, risk, and ops teams. - Combine architecture patterns ( ) with the [Governance toolkit](08-governance/) and [Collaboration playbooks](16-collaboration/) for executive visibility. ### Advisors, Clients, Friends & Family - Share the [Experience page](docs/experience.html) when introducing the hub to new collaborators. - Use to spin up proposals, meeting notes, and recap reports fast. ## 2. Map Your Architecture Playbook - Start with three core patterns: [Content Generation](01-design-patterns/content-generation.md), [Decision Support](01-design-patterns/decision-support.md), and [Model Lifecycle Management](01-design-patterns/model-lifecycle-management.md). - Explore the [Concept decks](12-concepts/) for mental models (retrieval, evaluation, observability, safety) you can present to stakeholders. - Browse [Platforms](docs/platforms.html) and [Cloud blueprints](docs"
+    "excerpt": "# Start Here — Build Your AI Architect Command Center You’re here to ship real AI value, guide stakeholders with confidence, and show your work. This quickstart orients you to the refreshed curriculum so you can choose the right lane, lock in your learning rhythm, and publish proof every week. ## 1. Map Your Learning S",
+    "content": "# Start Here — Build Your AI Architect Command Center You’re here to ship real AI value, guide stakeholders with confidence, and show your work. This quickstart orients you to the refreshed curriculum so you can choose the right lane, lock in your learning rhythm, and publish proof every week. ## 1. Map Your Learning Spine | Program Layer | Best For | Outcomes | Go-To Assets | | --- | --- | --- | --- | | **Launchpad — 100 Hours** | Builders who need momentum fast | Retrieval pipeline with eval harness, architecture brief, stakeholder recap | [100-Hour Plan](02-learning-paths/100-hour-ai-architect.md), [Design Patterns](01-design-patterns/), [RAG on Supabase](05-projects/rag-on-supabase.md) | | **Creator Launch Sequence** | Educators, creators, advocates | Workshops, newsletters, and explainer content anchored in safe prompting and governance | [Beginner Path](02-learning-paths/beginner.md), [Brand Voice](BRAND-VOICE.md), [Article Outlines](09-articles/) | | **Professional Architect Studio** | Staff/principal ICs, AI product leads | Multi-model system design, observability rollout, executive reviews | [Professional Path](02-learning-paths/professional.md), [Observability Playbook](15-workflows/observability-playbook.md), [Eval Harness](05-projects/evals-langfuse.md) | | **AI CoE Bootcamp** | Platform leaders, transformation teams | Governance baseline, platform roadmap, adoption plan | [Bootcamp](02-learning-paths/bootcamp.md), [Governance Toolkit](08-governance/), [Collaboration Rituals](16-collaboration/) | | **Agentic Systems Lab** | Advanced builders, R&D squads | Agent orchestration with tracing, guardrails, and UX | [Agentic Code Swarms](02-learning-paths/agentic-code-swarms.md), [Agentic SaaS Planner](05-projects/agentic-saas-planner.md) | Need the full rationale behind each layer? Read the [Curriculum Architecture](02-learning-paths/curriculum-architecture.md). ## 2. Run the Weekly Value Loop 1. **Discover the stakeholder need.** Use the discovery questions p"
   }
 ]


### PR DESCRIPTION
## Summary
- add a curriculum architecture map linking every learning layer to flagship outcomes, assets, and teaching rhythms
- rewrite the Start Here entry point and README highlights to orient visitors around the upgraded curriculum and delivery model
- expand each learning path with week-by-week structure, outcomes, tooling guidance, and assessment rubrics

## Testing
- npm run build:index

------
https://chatgpt.com/codex/tasks/task_e_68cb3d6f5cb88320be771d69cd518bcd