### PR TITLE
fix: redirect AI Architect Academy domain root

### DIFF
--- a/redirect-bridge/redirects.json
+++ b/redirect-bridge/redirects.json
@@ -1,0 +1,14 @@
+[
+  {
+    "source": "/",
+    "destination": "https://starlightintelligence.academy/",
+    "statusCode": 308,
+    "preserveQueryParams": false
+  },
+  {
+    "source": "/continue",
+    "destination": "https://starlightintelligence.academy/",
+    "statusCode": 308,
+    "preserveQueryParams": false
+  }
+]

--- a/redirect-bridge/tests/bridge.test.mjs
+++ b/redirect-bridge/tests/bridge.test.mjs
@@ -20,10 +20,15 @@ test("keeps the transition truthful and avoids a duplicate offer", () => {
   assert.doesNotMatch(html, /guaranteed|certification|cohort|price|discount|limited seats|job placement/i);
 });
 
-test("exposes a visible destination and a permanent continuation route", () => {
+test("permanently redirects both the domain root and continuation route", () => {
   assert.match(html, /href="\/continue"[^>]*>Continue to the Academy<\/a>/);
   assert.ok(html.includes(`href="${destination}"`));
   assert.deepEqual(config.redirects, [
+    {
+      source: "/",
+      destination,
+      permanent: true,
+    },
     {
       source: "/continue",
       destination,

--- a/redirect-bridge/tests/bridge.test.mjs
+++ b/redirect-bridge/tests/bridge.test.mjs
@@ -6,6 +6,7 @@ const destination = "https://starlightintelligence.academy/";
 const html = await readFile(new URL("../index.html", import.meta.url), "utf8");
 const robots = await readFile(new URL("../robots.txt", import.meta.url), "utf8");
 const config = JSON.parse(await readFile(new URL("../vercel.json", import.meta.url), "utf8"));
+const redirects = JSON.parse(await readFile(new URL("../redirects.json", import.meta.url), "utf8"));
 
 test("declares one exact canonical destination", () => {
   const canonicalLinks = html.match(/<link rel="canonical" href="[^"]+"/g) ?? [];
@@ -20,21 +21,33 @@ test("keeps the transition truthful and avoids a duplicate offer", () => {
   assert.doesNotMatch(html, /guaranteed|certification|cohort|price|discount|limited seats|job placement/i);
 });
 
-test("permanently redirects both the domain root and continuation route", () => {
+test("permanently redirects both legacy routes without leaking query parameters", () => {
   assert.match(html, /href="\/continue"[^>]*>Continue to the Academy<\/a>/);
   assert.ok(html.includes(`href="${destination}"`));
-  assert.deepEqual(config.redirects, [
+  assert.equal(config.bulkRedirectsPath, "redirects.json");
+  assert.equal(config.redirects, undefined);
+  assert.deepEqual(redirects, [
     {
       source: "/",
       destination,
-      permanent: true,
+      statusCode: 308,
+      preserveQueryParams: false,
     },
     {
       source: "/continue",
       destination,
-      permanent: true,
+      statusCode: 308,
+      preserveQueryParams: false,
     },
   ]);
+
+  for (const input of ["/?utm_source=legacy", "/continue?ref=old-academy"]) {
+    const request = new URL(input, "https://aiarchitectacademy.com");
+    const rule = redirects.find(({ source }) => source === request.pathname);
+    assert.equal(rule?.destination, destination);
+    assert.equal(rule?.statusCode, 308);
+    assert.equal(rule?.preserveQueryParams, false);
+  }
 });
 
 test("is intentionally noindex while allowing crawlers to observe the directive", () => {

--- a/redirect-bridge/vercel.json
+++ b/redirect-bridge/vercel.json
@@ -4,6 +4,11 @@
   "trailingSlash": false,
   "redirects": [
     {
+      "source": "/",
+      "destination": "https://starlightintelligence.academy/",
+      "permanent": true
+    },
+    {
       "source": "/continue",
       "destination": "https://starlightintelligence.academy/",
       "permanent": true

--- a/redirect-bridge/vercel.json
+++ b/redirect-bridge/vercel.json
@@ -2,18 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "cleanUrls": true,
   "trailingSlash": false,
-  "redirects": [
-    {
-      "source": "/",
-      "destination": "https://starlightintelligence.academy/",
-      "permanent": true
-    },
-    {
-      "source": "/continue",
-      "destination": "https://starlightintelligence.academy/",
-      "permanent": true
-    }
-  ],
+  "bulkRedirectsPath": "redirects.json",
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Outcome

Makes the deployed project root and `/continue` return one-hop HTTP 308 redirects to the exact canonical Academy URL: `https://starlightintelligence.academy/`.

## Root cause

The consolidation bridge originally redirected only `/continue`; adding a standard Vercel redirect for `/` still preserved incoming query parameters. That violated the cutover contract because tracking or legacy query data could leak into the canonical destination.

## Changes

- move `/` and `/continue` into versioned Vercel bulk redirect data
- set `statusCode: 308` and `preserveQueryParams: false` explicitly on both rules
- extend the contract test with query-bearing root and continuation inputs

## Impact

Once merged and deployed, both routes return the same exact `Location: https://starlightintelligence.academy/`, including requests containing query strings. DNS and registrar changes remain explicitly out of scope and human-gated.

## Validation

- `cd redirect-bridge && npm test` — 7/7 passing
- `git diff --check`
- `vercel.json` and `redirects.json` parse as valid JSON
- Link Check and Claude AI Assistant — passing
- CodeRabbit and Vercel — passing
- exact-head preview `dpl_GjU1NgPk9ESL95epxJa1gdezpE5q` — READY
- protected preview root response — HTTP 308 with exact `Location: https://starlightintelligence.academy/`

This PR remains draft for independent verification. It does not merge, promote, or change DNS.
