### PR TITLE
feat(release): add consolidated Academy support ledger

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,29 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+      - no-user-impact
+  categories:
+    - title: Consolidation and routing
+      labels:
+        - consolidation
+        - routing
+        - migration
+    - title: Learning experience and curriculum
+      labels:
+        - feature
+        - curriculum
+        - learning
+        - experience
+    - title: Trust, security, and governance
+      labels:
+        - security
+        - governance
+        - reliability
+        - compliance
+    - title: Documentation and evidence
+      labels:
+        - documentation
+    - title: Other meaningful changes
+      labels:
+        - "*"

--- a/.github/scripts/release-ledger.test.mjs
+++ b/.github/scripts/release-ledger.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { expectedPullRequests, loadLedger, validateLedger } from "./validate-release-ledger.mjs";
+
+test("canonical ledger satisfies the Academy support contract", async () => {
+  const ledger = await loadLedger();
+  assert.deepEqual(validateLedger(ledger), []);
+});
+
+test("every merged pull request receipt appears exactly once", async () => {
+  const ledger = await loadLedger();
+  const actual = ledger.releases
+    .flatMap((release) => release.sourcePullRequests)
+    .sort((a, b) => a - b);
+  assert.deepEqual(actual, expectedPullRequests);
+});
+
+test("consolidation, indexing, and production authority stay bounded", async () => {
+  const ledger = await loadLedger();
+  assert.equal(ledger.repository.role, "consolidated-learning-support");
+  assert.equal(ledger.repository.indexing, "noindex");
+  assert.equal(ledger.releasePolicy.githubReleaseMode, "draft-only");
+  assert.equal(ledger.releasePolicy.canonicalDestination, "https://starlightintelligence.academy/");
+  assert.equal(ledger.releasePolicy.domainMutation, "human-gated");
+  assert.equal(ledger.releasePolicy.productionProof, "post-deploy-route-audit-required");
+  assert.equal(ledger.production.liveVerification, "custom-domain-contract-mismatch-observed");
+  assert.ok(ledger.releases.every((release) => release.status === "merged"));
+  assert.ok(ledger.releases.every((release) => release.limitations.length > 0));
+});
+
+test("draft workflow cannot publish or tag an unreviewed branch", async () => {
+  const workflow = await readFile(new URL("../workflows/draft-release.yml", import.meta.url), "utf8");
+  assert.match(workflow, /tags:\s*\n\s*- "v\*\.\*\.\*"/);
+  assert.match(workflow, /git cat-file -t/);
+  assert.match(workflow, /git merge-base --is-ancestor/);
+  assert.match(workflow, /gh release create/);
+  assert.match(workflow, /--draft/);
+  assert.doesNotMatch(workflow, /--draft=false|gh release edit|--latest/);
+});
+
+test("validator rejects missing, duplicated, or unauthorized history", async () => {
+  const canonical = await loadLedger();
+
+  const missing = structuredClone(canonical);
+  missing.releases[0].sourcePullRequests = [];
+  assert.ok(validateLedger(missing).length > 0);
+
+  const duplicated = structuredClone(canonical);
+  duplicated.releases[1].sourcePullRequests.push(21);
+  assert.ok(validateLedger(duplicated).length > 0);
+
+  const unauthorized = structuredClone(canonical);
+  unauthorized.releasePolicy.domainMutation = "automatic";
+  assert.ok(validateLedger(unauthorized).length > 0);
+});

--- a/.github/scripts/validate-release-ledger.mjs
+++ b/.github/scripts/validate-release-ledger.mjs
@@ -1,0 +1,93 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const ledgerUrl = new URL("../../docs/releases/release-ledger.json", import.meta.url);
+
+export const expectedPullRequests = [9, 10, 11, 13, 14, 17, 18, 19, 21];
+
+export async function loadLedger() {
+  return JSON.parse(await readFile(ledgerUrl, "utf8"));
+}
+
+export function validateLedger(ledger) {
+  const errors = [];
+  const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+  const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+  if (ledger.schemaVersion !== "1.0") errors.push("schemaVersion must be 1.0");
+  if (!datePattern.test(ledger.updatedAt ?? "")) errors.push("updatedAt must be YYYY-MM-DD");
+  if (ledger.repository?.owner !== "frankxai" || ledger.repository?.name !== "ai-architect-academy") {
+    errors.push("repository must be frankxai/ai-architect-academy");
+  }
+  if (ledger.repository?.publicDomain !== "aiarchitectacademy.com") {
+    errors.push("publicDomain must be aiarchitectacademy.com");
+  }
+  if (ledger.repository?.role !== "consolidated-learning-support") {
+    errors.push("repository role must remain consolidated-learning-support");
+  }
+  if (ledger.repository?.indexing !== "noindex") errors.push("legacy surface must remain noindex");
+  if (ledger.releasePolicy?.githubReleaseMode !== "draft-only") {
+    errors.push("GitHub releases must remain draft-only");
+  }
+  if (ledger.releasePolicy?.canonicalDestination !== "https://starlightintelligence.academy/") {
+    errors.push("canonical destination must remain Starlight Intelligence Academy");
+  }
+  if (ledger.releasePolicy?.productionProof !== "post-deploy-route-audit-required") {
+    errors.push("production proof must require a post-deploy route audit");
+  }
+  if (ledger.releasePolicy?.domainMutation !== "human-gated") {
+    errors.push("domain mutation must remain human-gated");
+  }
+  if (!Array.isArray(ledger.releases) || ledger.releases.length !== 6) {
+    errors.push("ledger must contain six grouped release records");
+    return errors;
+  }
+
+  const slugs = new Set();
+  const pullRequests = [];
+  let previousDate = "9999-12-31";
+
+  for (const [index, release] of ledger.releases.entries()) {
+    const prefix = `releases[${index}]`;
+    if (!slugPattern.test(release.slug ?? "")) errors.push(`${prefix}.slug is invalid`);
+    if (slugs.has(release.slug)) errors.push(`${prefix}.slug is duplicated`);
+    slugs.add(release.slug);
+    if (!datePattern.test(release.mergedThrough ?? "")) errors.push(`${prefix}.mergedThrough is invalid`);
+    if (!datePattern.test(release.recordedAt ?? "")) errors.push(`${prefix}.recordedAt is invalid`);
+    if ((release.mergedThrough ?? "") > previousDate) errors.push("releases must be newest first");
+    previousDate = release.mergedThrough;
+    if (release.status !== "merged") errors.push(`${prefix}.status must be merged`);
+    if (typeof release.title !== "string" || release.title.length < 8) errors.push(`${prefix}.title is too short`);
+    if (typeof release.summary !== "string" || release.summary.length < 40) errors.push(`${prefix}.summary is too short`);
+    if (!Array.isArray(release.highlights) || release.highlights.length < 2) errors.push(`${prefix} needs at least two highlights`);
+    if (!Array.isArray(release.limitations) || release.limitations.length < 1) errors.push(`${prefix} needs at least one limitation`);
+    if (!Array.isArray(release.sourcePullRequests) || release.sourcePullRequests.length < 1) {
+      errors.push(`${prefix} needs source pull requests`);
+    } else {
+      pullRequests.push(...release.sourcePullRequests);
+    }
+  }
+
+  const uniquePullRequests = new Set(pullRequests);
+  if (uniquePullRequests.size !== pullRequests.length) errors.push("source pull requests must be unique across records");
+  const actual = [...uniquePullRequests].sort((a, b) => a - b);
+  if (JSON.stringify(actual) !== JSON.stringify(expectedPullRequests)) {
+    errors.push(`expected exact PR coverage of ${expectedPullRequests.length}; received ${actual.length}`);
+  }
+
+  return errors;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const ledger = await loadLedger();
+  const errors = validateLedger(ledger);
+  if (errors.length) {
+    console.error(`Release ledger validation failed:\n- ${errors.join("\n- ")}`);
+    process.exit(1);
+  }
+  const pullRequestCount = ledger.releases.reduce(
+    (total, release) => total + release.sourcePullRequests.length,
+    0,
+  );
+  console.log(`Release ledger valid: ${ledger.releases.length} records, ${pullRequestCount} PR receipts.`);
+}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,60 @@
+name: Draft GitHub release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ai-architect-academy-draft-release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  draft-release:
+    name: Validate tag and create draft
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out full history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Require annotated semantic-version tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Expected an annotated tag such as v1.2.3; received $tag" >&2
+            exit 1
+          fi
+          if [[ "$(git cat-file -t "$tag")" != "tag" ]]; then
+            echo "$tag must be an annotated tag." >&2
+            exit 1
+          fi
+
+      - name: Require commit reachable from main
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin main --no-tags
+          commit="$(git rev-list -n 1 "$GITHUB_REF_NAME")"
+          if ! git merge-base --is-ancestor "$commit" origin/main; then
+            echo "$GITHUB_REF_NAME does not point to a commit reachable from origin/main." >&2
+            exit 1
+          fi
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release create "$GITHUB_REF_NAME" \
+            --draft \
+            --generate-notes \
+            --title "$GITHUB_REF_NAME"

--- a/.github/workflows/release-contract.yml
+++ b/.github/workflows/release-contract.yml
@@ -1,0 +1,55 @@
+name: Release contract
+
+on:
+  pull_request:
+    paths:
+      - ".github/release.yml"
+      - ".github/scripts/release-*"
+      - ".github/scripts/validate-release-ledger.mjs"
+      - ".github/workflows/draft-release.yml"
+      - ".github/workflows/release-contract.yml"
+      - "CHANGELOG.md"
+      - "RELEASING.md"
+      - "docs/releases/**"
+      - "docs/RELEASE-FOUNDATION-*.md"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/release.yml"
+      - ".github/scripts/release-*"
+      - ".github/scripts/validate-release-ledger.mjs"
+      - ".github/workflows/draft-release.yml"
+      - ".github/workflows/release-contract.yml"
+      - "CHANGELOG.md"
+      - "RELEASING.md"
+      - "docs/releases/**"
+      - "docs/RELEASE-FOUNDATION-*.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ai-architect-academy-release-contract-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate Academy support ledger
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24"
+
+      - name: Validate ledger
+        run: node .github/scripts/validate-release-ledger.mjs
+
+      - name: Test release contract
+        run: node --test .github/scripts/release-ledger.test.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# AI Architect Academy support changelog
+
+This evidence-led history records meaningful changes merged into `frankxai/ai-architect-academy`. The repository is now a consolidated learning-support and redirect surface, not an independent Academy funnel. Canonical public Academy updates belong to [Starlight Intelligence Academy](https://starlightintelligence.academy/).
+
+The machine-readable source is [`docs/releases/release-ledger.json`](docs/releases/release-ledger.json). A merged change or READY Vercel deployment is not current production proof: direct checks on 2026-08-10 returned the legacy 200 page at `aiarchitectacademy.com/` and `/continue`, rather than the repository's intended 308 redirect contract.
+
+## Unreleased
+
+- Record only coherent curriculum, consolidation, routing, trust, or maintenance changes.
+- Quiet weeks, formatting-only edits, and raw content refreshes without a meaningful contract change do not require a release.
+- Do not create a second indexed changelog or product offer on the legacy domain.
+
+## 2026-08-10 — Repository media governance
+
+Added a trusted, dependency-free media guard that blocks new repository bloat, constrains governed assets, and protects its own policy roots. Product behavior and the redirect contract were intentionally unchanged.
+
+Receipt: [#21](https://github.com/frankxai/ai-architect-academy/pull/21)
+
+## 2026-07-24 — Academy consolidation bridge
+
+Consolidated the legacy Academy address into Starlight Intelligence Academy through a noindex transition surface, exact 308 route rules, restrictive headers, and a canonical Vercel project mapping.
+
+Receipts: [#18](https://github.com/frankxai/ai-architect-academy/pull/18), [#19](https://github.com/frankxai/ai-architect-academy/pull/19)
+
+## 2026-02-10 — Slack collaboration micro-module
+
+Added a Slack-focused collaboration lesson and reusable prompt vault covering channel, Canvas, and List workflows for agent-supported teams.
+
+Receipt: [#17](https://github.com/frankxai/ai-architect-academy/pull/17)
+
+## 2025-09-17 — Experience hub and navigation
+
+Reworked the static documentation experience around a unified Academy story, refreshed navigation and topic surfaces, and expanded search, sitemap, diagrams, and contributor assets.
+
+Receipts: [#13](https://github.com/frankxai/ai-architect-academy/pull/13), [#14](https://github.com/frankxai/ai-architect-academy/pull/14)
+
+## 2025-09-13 — Search and agentic swarms
+
+Added repository-wide client-side documentation search and a runnable Agentic Code Swarms module with Python orchestration primitives, examples, a SaaS planner, a Streamlit interface, and learning-path guidance.
+
+Receipts: [#10](https://github.com/frankxai/ai-architect-academy/pull/10), [#11](https://github.com/frankxai/ai-architect-academy/pull/11)
+
+## 2025-09-04 — Visual evidence and README refresh
+
+Added repeatable Puppeteer screenshot capture, initial site screenshots, and clearer context across the README, learning patterns, projects, and resource lists.
+
+Receipt: [#9](https://github.com/frankxai/ai-architect-academy/pull/9)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,60 @@
+# Releasing AI Architect Academy support history
+
+`ai-architect-academy` is a template-study and consolidated learning-support repository. Its `redirect-bridge` is intended to move legacy visitors to Starlight Intelligence Academy; it must not become a second marketing funnel, indexed changelog, enrollment surface, or source of competing Academy claims.
+
+## Meaningful-change rule
+
+Create a release candidate only when a coherent curriculum, lab, learning-tool, consolidation, routing, trust, security, or repository-governance contract changes. Do not release quiet weeks, formatting-only edits, raw content refreshes without audience impact, or dependency churn that does not change supported behavior.
+
+Portfolio discovery may run weekly through [`frankx-domain-command` PR #34](https://github.com/frankxai/frankx-domain-command/pull/34), but this repository adds no second schedule. Human review decides whether evidence warrants a release.
+
+## Versioned support contract
+
+Semantic Versioning requires a declared public API. For this repository, that contract includes:
+
+- the Socratic instructor protocol, commands, labs, and learner-facing source structure;
+- the redirect bridge's `/` and `/continue` routes, 308 response behavior, canonical destination, query handling, indexing directives, and security headers;
+- the machine-readable support-history schema and its exact merged-PR coverage;
+- the human authority boundary for domains, DNS, aliases, TLS, production promotion, and release publication.
+
+Choose versions from changes to that contract:
+
+- `PATCH`: compatible curriculum correction, evidence clarification, test improvement, or security hardening.
+- `MINOR`: compatible lab, command, learning module, ledger field, or redirect capability.
+- `MAJOR`: intentional incompatible change to learner commands, lab structure, route semantics, canonical destination, schemas, or authority boundaries.
+
+Do not infer the initial version from package files, dates, commits, screenshots, or deployment IDs. Document the first-version rationale against the declared support contract before tagging.
+
+## Release procedure
+
+1. Update [`docs/releases/release-ledger.json`](docs/releases/release-ledger.json) and `CHANGELOG.md` with merged PR receipts, dated observations, and limitations.
+2. Run `node .github/scripts/validate-release-ledger.mjs` and `node --test .github/scripts/release-ledger.test.mjs`.
+3. Run `npm test --prefix redirect-bridge` when the bridge, canonical destination, headers, or route claims change.
+4. Open or update a draft PR and let the lightweight `Release contract` and trusted `Media Guard` workflows pass.
+5. For bridge or domain-affecting work, inspect one exact-head Vercel preview and verify desktop, mobile, keyboard, reflow, reduced motion, canonical metadata, noindex headers, and both redirect routes.
+6. Merge through normal review. Do not tag an unmerged branch.
+7. From reviewed `main`, create an annotated semantic-version tag: `git tag -a vX.Y.Z -m "AI Architect Academy vX.Y.Z"`.
+8. Push the exact tag. The workflow verifies that it is annotated and reachable from `origin/main`, then creates a GitHub release as a draft.
+9. Review generated notes, remove private or irrelevant material, state the consolidation and production limitations, and publish only with maintainer approval.
+10. After an explicitly approved production or domain action, verify `aiarchitectacademy.com/`, `/continue`, and the `www` host against the exact 308, destination, query, cache, security, and indexing contract.
+
+## Draft and cost controls
+
+- Tag pushes never publish automatically.
+- Generated notes use `.github/release.yml` categories and receive human review.
+- Release validation installs no dependencies and is capped at five minutes.
+- Superseded workflow runs are cancelled.
+- No duplicate weekly schedule is added; portfolio radar owns discovery.
+- Domain, DNS, alias, TLS, production, and public-release actions remain human-gated.
+
+## Public changelog and SEO boundary
+
+The legacy bridge remains `noindex` and points to `https://starlightintelligence.academy/`. Do not create structured editorial pages, duplicate Academy offers, or an indexed `/changelog` here. Customer-facing Academy progress belongs on the canonical Academy; repository release notes remain an operator and contributor record.
+
+As of 2026-08-10, Vercel reported a READY production deployment for commit `8b216c9`, but direct HTTPS checks returned the legacy 200 Next.js page for both `/` and `/continue`. Treat that as an unresolved production-contract mismatch until an approved action is followed by a fresh route receipt.
+
+## Primary-source basis
+
+- [GitHub generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) support categorized notes and require review of generated contents.
+- [GitHub releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) are tag-based records and support draft review before publication.
+- [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html) requires a declared public API and immutable released contents.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@
 
 Create a release candidate only when a coherent curriculum, lab, learning-tool, consolidation, routing, trust, security, or repository-governance contract changes. Do not release quiet weeks, formatting-only edits, raw content refreshes without audience impact, or dependency churn that does not change supported behavior.
 
-Portfolio discovery may run weekly through [`frankx-domain-command` PR #34](https://github.com/frankxai/frankx-domain-command/pull/34), but this repository adds no second schedule. Human review decides whether evidence warrants a release.
+Portfolio discovery may run weekly through the private portfolio control plane, but this public repository adds no second schedule or private control-plane link. Human review decides whether evidence warrants a release.
 
 ## Versioned support contract
 

--- a/docs/RELEASE-FOUNDATION-2026-08-10.md
+++ b/docs/RELEASE-FOUNDATION-2026-08-10.md
@@ -1,0 +1,53 @@
+# AI Architect Academy release foundation receipt
+
+Date: 2026-08-10
+
+Repository: `frankxai/ai-architect-academy` (public template-study and consolidated learning-support repository)
+
+Branch: `agent/codex/release-foundation-20260810`
+
+## Outcome
+
+The repository now has an evidence-led support-history contract covering all nine pull requests merged from 2025-09-04 through 2026-08-10. Each PR appears exactly once in one of six meaningful groups. Every group carries a limitation and uses status `merged`.
+
+The release workflow accepts only annotated `vMAJOR.MINOR.PATCH` tags whose commits are reachable from `origin/main`. It creates a draft GitHub release and never publishes automatically.
+
+## Routing decision
+
+This repository does not receive a public changelog site. The merged consolidation bridge names `https://starlightintelligence.academy/` as the canonical Academy, marks the legacy surface `noindex`, and forbids a duplicate offer. Repository release notes remain a support and maintainer record.
+
+Open PR #16 is not merged, has stale failing checks from 2025-09-18, and is intentionally excluded from the release ledger.
+
+## Live production evidence
+
+- Vercel project `aiarchitectacademy` is connected to `frankxai/ai-architect-academy` with `redirect-bridge` as its recorded root directory.
+- Vercel reported production deployment `dpl_DatvXzKVQDfGCMAbGVJpMDEzQErG` for commit `8b216c9` as `READY` on 2026-08-10, with the apex, `www`, and project aliases attached.
+- Direct HTTPS headers on 2026-08-10 returned HTTP 200 for both `https://aiarchitectacademy.com/` and `/continue`, with `X-Matched-Path: /` and an aged cached Next.js response. The repository contract requires 308 responses to Starlight Intelligence Academy.
+- Subsequent Windows Schannel probes for `www` and the canonical destination were inconclusive because the local security provider failed during TLS initialization.
+
+The READY deployment and alias inventory therefore do not prove the custom-domain route contract. The mismatch requires a human-approved Vercel/domain investigation and a fresh external route receipt.
+
+## Safety and cost decisions
+
+- Existing curriculum, labs, bridge HTML, redirects, headers, media policy, Vercel configuration, and deployment state are unchanged.
+- No second indexed Academy, changelog page, weekly schedule, version, tag, GitHub release, merge, production deployment, DNS/domain/alias/TLS mutation, or external send was created.
+- The lightweight release contract uses pinned actions, Node 24, no dependency install, run cancellation, and a five-minute cap.
+- Portfolio discovery remains centralized in `frankx-domain-command`; quiet weeks produce no repository release.
+- Machine preflight admitted one serial interactive workload and paused new swarms. No local build, browser, or additional parallel repo lane was started.
+
+## Evidence gates
+
+- [x] Ledger validator reports six records and nine unique PR receipts.
+- [x] Node contract tests pass.
+- [x] Redirect bridge tests pass.
+- [x] Workflow YAML parses.
+- [x] Patch hygiene, language scan, media guard, and staged security scan pass.
+- [ ] Draft pull request release-contract checks are inspected remotely.
+
+## Follow-up sequence
+
+1. Review and merge this release foundation.
+2. Investigate the Vercel alias/custom-domain mismatch under explicit human approval; do not change DNS or production routing speculatively.
+3. After any approved correction, verify apex, `www`, `/continue`, query stripping, `Location`, cache, security, and `X-Robots-Tag` behavior from an external client.
+4. Record the redacted route receipt and only then update the ledger's production proof state.
+5. Define the initial semantic version against the declared support contract before creating an annotated tag and reviewing the generated draft release.

--- a/docs/releases/release-ledger.json
+++ b/docs/releases/release-ledger.json
@@ -1,0 +1,143 @@
+{
+  "schemaVersion": "1.0",
+  "updatedAt": "2026-08-10",
+  "repository": {
+    "owner": "frankxai",
+    "name": "ai-architect-academy",
+    "visibility": "public",
+    "role": "consolidated-learning-support",
+    "publicDomain": "aiarchitectacademy.com",
+    "indexing": "noindex"
+  },
+  "production": {
+    "vercelProject": "aiarchitectacademy",
+    "projectId": "prj_EhWOyjmGYVOo8Z90tcmgGc1GP5rH",
+    "rootDirectory": "redirect-bridge",
+    "latestObservedDeployment": "dpl_DatvXzKVQDfGCMAbGVJpMDEzQErG",
+    "latestObservedCommit": "8b216c9914b6105c7c19b2f063ea6a7581c81113",
+    "deploymentState": "READY",
+    "liveVerification": "custom-domain-contract-mismatch-observed"
+  },
+  "releasePolicy": {
+    "githubReleaseMode": "draft-only",
+    "versioning": "annotated-semantic-tags-only",
+    "cadence": "meaningful-change-only",
+    "productionProof": "post-deploy-route-audit-required",
+    "canonicalDestination": "https://starlightintelligence.academy/",
+    "canonicalUpdates": "starlight-intelligence-academy",
+    "publicChangelog": "canonical-destination-only",
+    "domainMutation": "human-gated"
+  },
+  "releases": [
+    {
+      "slug": "repository-media-governance",
+      "status": "merged",
+      "mergedThrough": "2026-08-10",
+      "recordedAt": "2026-08-10",
+      "title": "Repository media governance",
+      "summary": "Added a trusted, dependency-free media guard that blocks new repository bloat and protects its own policy roots without changing the Academy product or redirect behavior.",
+      "category": "trust-and-governance",
+      "audience": "maintainers-and-reviewers",
+      "highlights": [
+        "Enforced bounded file, sidecar, governed-media, and total pull-request size limits with explicit archive and binary-format exclusions.",
+        "Validated the trusted base policy before inspecting an untrusted pull-request tree and required exact-head approval for policy changes."
+      ],
+      "sourcePullRequests": [21],
+      "limitations": [
+        "This governance change did not correct, promote, or verify the custom-domain redirect contract."
+      ]
+    },
+    {
+      "slug": "academy-consolidation-bridge",
+      "status": "merged",
+      "mergedThrough": "2026-07-24",
+      "recordedAt": "2026-08-10",
+      "title": "Academy consolidation bridge",
+      "summary": "Consolidated the legacy AI Architect Academy address into Starlight Intelligence Academy through a noindex bridge and permanent route contract.",
+      "category": "consolidation-and-routing",
+      "audience": "legacy-visitors-and-operators",
+      "highlights": [
+        "Added a restrained transition surface that names the canonical Academy without a duplicate offer, enrollment claim, or automatic forwarding timer.",
+        "Defined exact 308 redirects for the root and /continue routes, stripped query parameters, and applied restrictive security and noindex headers.",
+        "Reconnected the existing Vercel project to the canonical repository with redirect-bridge as its root directory."
+      ],
+      "sourcePullRequests": [18, 19],
+      "limitations": [
+        "A direct 2026-08-10 live probe observed HTTP 200 legacy Next.js output on both the root and /continue routes instead of the repository's 308 contract.",
+        "Domain, DNS, alias, TLS, and production-promotion changes remain human-gated and were not performed by this release foundation."
+      ]
+    },
+    {
+      "slug": "slack-collaboration-micro-module",
+      "status": "merged",
+      "mergedThrough": "2026-02-10",
+      "recordedAt": "2026-08-10",
+      "title": "Slack collaboration micro-module",
+      "summary": "Added a Slack-focused collaboration lesson and reusable prompt vault covering channel, Canvas, and List workflows for agent-supported teams.",
+      "category": "learning-experience",
+      "audience": "students-and-team-operators",
+      "highlights": [
+        "Registered a new collaboration lesson in the micro-learning atlas.",
+        "Added a reusable Slack collaboration prompt vault for team workflows."
+      ],
+      "sourcePullRequests": [17],
+      "limitations": [
+        "This is historical curriculum content, not evidence of a hosted Slack integration or current third-party service availability."
+      ]
+    },
+    {
+      "slug": "experience-hub-and-navigation",
+      "status": "merged",
+      "mergedThrough": "2025-09-17",
+      "recordedAt": "2026-08-10",
+      "title": "Experience hub and navigation",
+      "summary": "Reworked the documentation experience around a unified Academy story, refreshed navigation and topic surfaces, and expanded discoverability assets.",
+      "category": "experience-and-discovery",
+      "audience": "learners-and-resource-readers",
+      "highlights": [
+        "Added the Experience hub, refreshed homepage and topic navigation, and documented brand voice and audience personas.",
+        "Expanded the static site, search index, sitemap, diagrams, issue templates, and resource presentation."
+      ],
+      "sourcePullRequests": [13, 14],
+      "limitations": [
+        "The historical static experience was later superseded by the consolidation bridge and is not the canonical public Academy surface."
+      ]
+    },
+    {
+      "slug": "search-and-agentic-swarms",
+      "status": "merged",
+      "mergedThrough": "2025-09-13",
+      "recordedAt": "2026-08-10",
+      "title": "Search and agentic swarms",
+      "summary": "Added repository-wide documentation search and a runnable Agentic Code Swarms learning module with examples, orchestration code, and a Streamlit interface.",
+      "category": "curriculum-and-tooling",
+      "audience": "ai-architecture-learners",
+      "highlights": [
+        "Generated a static search index and client-side search UI with section filtering and navigation links.",
+        "Added Python swarm primitives, examples, a SaaS planner, a Streamlit interface, learning-path documentation, and toolchain guidance."
+      ],
+      "sourcePullRequests": [10, 11],
+      "limitations": [
+        "The merged module included historical runtime examples and generated artifacts; this ledger does not certify their present dependency, security, or production readiness."
+      ]
+    },
+    {
+      "slug": "visual-evidence-and-readme",
+      "status": "merged",
+      "mergedThrough": "2025-09-04",
+      "recordedAt": "2026-08-10",
+      "title": "Visual evidence and README refresh",
+      "summary": "Added a repeatable screenshot capture path, repository screenshots, and clearer context across the README, patterns, projects, and resource lists.",
+      "category": "documentation-and-evidence",
+      "audience": "learners-and-contributors",
+      "highlights": [
+        "Added a Puppeteer screenshot workflow and initial index and project captures.",
+        "Refreshed the README and added contextual descriptions across major learning and resource documents."
+      ],
+      "sourcePullRequests": [9],
+      "limitations": [
+        "These historical screenshots describe the former static experience and are not current visual proof for the consolidated public destination."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Outcome

Adds an evidence-led release foundation for the consolidated AI Architect Academy support repository.

- Backfills all 9 merged PRs into 6 meaningful, non-overlapping release groups.
- Adds a machine-validated ledger, categorized generated-note config, and draft-only annotated-tag workflow.
- Keeps the legacy Academy surface `noindex` and directs canonical public updates to Starlight Intelligence Academy.
- Adds no second weekly schedule; portfolio discovery remains centralized in frankx-domain-command.

## Production finding

The repository's bridge contract requires permanent 308 redirects for `/` and `/continue`, but direct HTTPS checks on 2026-08-10 returned the legacy 200 Next.js page for both paths. Vercel reports the current main deployment as READY with the custom domains attached, so the ledger records this as an unresolved custom-domain contract mismatch rather than claiming production success.

Domain, DNS, alias, TLS, and production changes remain human-gated and are not part of this PR.

## Verification

- `node .github/scripts/validate-release-ledger.mjs`
- `node --test .github/scripts/release-ledger.test.mjs`
- `npm test --prefix redirect-bridge`
- `node scripts/media-guard.mjs --base origin/main`
- workflow YAML parse, staged public-artifact scan, and `git diff --check`

## Boundaries

No curriculum, lab, redirect, bridge UI, security headers, deployment configuration, domain, release, tag, or external communication is changed.