### PR TITLE
docs: plugin adopt lab for humans and agents

### DIFF
--- a/06-agent-workflows/README.md
+++ b/06-agent-workflows/README.md
@@ -23,6 +23,11 @@ This directory contains **step-by-step workflows** for building AI systems with 
 
 ## 🚀 Available Workflow
 
+### [Adopt the AI Architect plugin](plugin-adopt.md)
+- Run: the gated architecture team inside a customer repo (plugin, conductor, MCP, or skills.sh)
+- Time: 30 minutes
+- Prerequisites: Node 20+, a throwaway git repo, no cloud account required
+
 ### [Claude SDK Agent Workflow](claude-code/claude-sdk-workflow.md)
 - Build: Autonomous agent using the Claude Agent SDK — computer use, tool orchestration, MCP integration
 - Time: 45-60 minutes

--- a/06-agent-workflows/plugin-adopt.md
+++ b/06-agent-workflows/plugin-adopt.md
@@ -1,0 +1,51 @@
+# Adopt the AI Architect plugin
+
+Humans and agents use the same contract. The plugin writes into **your** repo at
+`docs/architecture/`. It is not a hosted architect service.
+
+Source: https://github.com/frankxai/ai-architect  
+Process: `team/PROCESS.md` in that repo.
+
+## What you install
+
+| path | who | first move |
+|---|---|---|
+| Claude Code plugin | interactive humans | `/architect-init` then `/architect` |
+| skills.sh pack `ai-architect` | any skill host | copy SOP + WORKFLOW, follow SOP |
+| Conductor CLI | Codex and other CLIs | `node scripts/architect-conductor.mjs --root . card` |
+| MCP stdio `mcp/server.mjs` | Hermes and other MCP hosts | `architect_init` then `architect_card` |
+| `AGENTS.md` block | Cursor / Copilot / Windsurf | `install-cross-harness.mjs --agents-md` |
+
+Keys stay with the operator. Do not stand up a public MCP host.
+
+## Lifecycle (nine gates)
+
+frame → discover → flow → decide → cost → secure → prove → operate → verify
+
+`architecture.json` is the only resumable state. A FAIL earlier in the table
+blocks later `--stage` jumps.
+
+## Overlays (not extra gates)
+
+- `/architect-red` — attack evidence, trust, cost, human-gate bypass
+- `/architect-blue` — map each finding to a fail-closed control
+- `/architect-cloud` — compare clouds and harnesses with evidence, no provisioning
+
+Maker and checker are different models. Verify is a fresh context.
+
+## Human gates (never an agent)
+
+publish · external_send · spend · dns · credentials · destructive · legal_ip · brand_identity
+
+If a lab prompt would cross one of these, stop and name the gate.
+
+## Lab (30 minutes)
+
+1. Clone or submodule `frankxai/ai-architect` next to a throwaway git repo.
+2. `node scripts/architect-conductor.mjs --root <throwaway> init`
+3. `node scripts/architect-conductor.mjs --root <throwaway> card`
+4. Confirm the card's `write_paths` stay under `docs/architecture/`.
+5. Do **not** run `/architect-cloud` against a live account.
+
+Done when: SOP.md and WORKFLOW.md exist once, the card names `frame`, and no
+cloud resource was created.


### PR DESCRIPTION
## Why
Academy needed a real adopt path for the AI Architect plugin, conductor, MCP, and skills.sh pack.

## What
- `06-agent-workflows/plugin-adopt.md`
- README pointer

## Evidence
Markdown only. No production site.

## Human gates
Draft.