### PR TITLE
Adopt FSL-1.1-ALv2 and protect commercial IP

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,105 @@
-MIT License
+# Functional Source License, Version 1.1, ALv2 Future License
 
-Copyright (c) 2026 Frank Riemer
+## Abbreviation
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+FSL-1.1-ALv2
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+## Notice
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Copyright 2026 Frank Riemer
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,27 @@
+# Licensing
+
+**Current rights holder for original contributions:** Frank Riemer
+
+## Software
+
+Original source code, installable plugin logic, technical configuration, and
+technical documentation first published from 2026-08-27 are licensed under
+FSL-1.1-ALv2 unless a narrower file-level license applies. The license permits
+non-competing use, modification, and redistribution; each version converts to
+Apache-2.0 two years after publication.
+
+## Reserved material
+
+Official Arcanea or project canon, characters, lore, curriculum, proprietary
+methods, prompts not required to operate the software, datasets, books, music,
+images, video, generated outputs, designs, product copy, logos, names, and trade
+dress remain all rights reserved by Frank Riemer unless explicitly licensed.
+
+Third-party and fork-derived material remains under its original license and
+attribution requirements.
+
+Earlier releases carrying MIT or another public license remain governed by that
+license. This change does not revoke historical grants.
+
+A future Dutch eenmanszaak is not a separate copyright owner. A future BV must
+receive the IP through a written assignment.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,10 @@
+AI Architect Academy
+Copyright © 2026 Frank Riemer
+
+Original software is licensed under FSL-1.1-ALv2. Each version becomes
+available under Apache-2.0 on the second anniversary of its publication.
+
+Official canon, curriculum, editorial content, commercial methods, datasets,
+media, generated outputs, product copy, brand assets, and trademarks are not
+licensed as software unless they carry an express license. Third-party material
+remains governed by its original license and notices.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href="#interactive-labs"><img src="https://img.shields.io/badge/Labs-3%20Interactive-ff6b6b?style=flat-square" alt="Labs"/></a>
   <a href="#skills-library"><img src="https://img.shields.io/badge/Skills-23-blue?style=flat-square" alt="Skills"/></a>
   <a href="#learning-paths"><img src="https://img.shields.io/badge/Paths-5%20Tracks-purple?style=flat-square" alt="Learning Paths"/></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=flat-square" alt="License"/></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-FSL--1.1--ALv2-blue?style=flat-square" alt="License"/></a>
 </p>
 
 ---

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "puppeteer": "^22.12.1"
-  }
+  },
+  "license": "FSL-1.1-ALv2",
+  "author": "Frank Riemer <frank@frankx.ai>"
 }
-


### PR DESCRIPTION
Licenses future original AI Architect Academy software under FSL-1.1-ALv2, preserves historical grants, identifies Frank Riemer as the current rights holder, and excludes canon, curriculum, media, product content, and trademarks from the software grant. Part of frankxai/arcanea#114.