### PR TITLE
chore: install AI Architect Academy editorial contract

### DIFF
--- a/.agents/skills/frank-brand-editor/SKILL.md
+++ b/.agents/skills/frank-brand-editor/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: frank-brand-editor
+description: Use for any public copy in this repository. Load CREATOR.md, preserve facts and search intent, and run the Starlight editorial gate.
+---
+
+# Repository brand editor
+
+Read `CREATOR.md` and the managed editorial block in `AGENTS.md`. Apply them to websites, UI labels, articles, social copy, email, sales material, and scripts. Preserve exact quotations, code, legal wording, and necessary technical terms. Run the repository's pinned editorial audit before release.

--- a/.cursor/rules/editorial.mdc
+++ b/.cursor/rules/editorial.mdc
@@ -1,0 +1,18 @@
+---
+description: Portfolio brand and editorial contract
+alwaysApply: true
+---
+
+<!-- STARLIGHT-EDITORIAL:START -->
+## Editorial contract
+
+Brand: **AI Architect Academy** (`ai-architect-academy`)
+
+- Read `CREATOR.md` before changing public or customer-facing copy.
+- Apply the registered brand voice and the shared editorial gate.
+- Reject generated prestige language, rhetorical contrast formulas, invented claims, and abstract labels that hide simple facts.
+- Keep public labels in sentence case.
+- Run the changed-copy editorial audit before release.
+
+Pinned source: https://github.com/frankxai/starlight-design-intelligence/blob/50ae34c7ac06e6c083f277ca96c3bde8f0a39b43/brand-packs/ai-architect-academy/COPY.md
+<!-- STARLIGHT-EDITORIAL:END -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,13 @@
+<!-- STARLIGHT-EDITORIAL:START -->
+## Editorial contract
+
+Brand: **AI Architect Academy** (`ai-architect-academy`)
+
+- Read `CREATOR.md` before changing public or customer-facing copy.
+- Apply the registered brand voice and the shared editorial gate.
+- Reject generated prestige language, rhetorical contrast formulas, invented claims, and abstract labels that hide simple facts.
+- Keep public labels in sentence case.
+- Run the changed-copy editorial audit before release.
+
+Pinned source: https://github.com/frankxai/starlight-design-intelligence/blob/50ae34c7ac06e6c083f277ca96c3bde8f0a39b43/brand-packs/ai-architect-academy/COPY.md
+<!-- STARLIGHT-EDITORIAL:END -->

--- a/.github/workflows/starlight-editorial-contract.yml
+++ b/.github/workflows/starlight-editorial-contract.yml
@@ -1,0 +1,11 @@
+name: Starlight editorial contract
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  editorial-contract:
+    uses: frankxai/starlight-design-intelligence/.github/workflows/editorial-contract.yml@50ae34c7ac06e6c083f277ca96c3bde8f0a39b43

--- a/.starlight/editorial-contract.json
+++ b/.starlight/editorial-contract.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "starlight.editorial_contract.v1",
+  "brand_id": "ai-architect-academy",
+  "source": {
+    "repository": "frankxai/starlight-design-intelligence",
+    "ref": "50ae34c7ac06e6c083f277ca96c3bde8f0a39b43",
+    "profile": "brand-packs/ai-architect-academy/COPY.md",
+    "profile_sha256": "15f066f19f6159e8b35f58feacf31ce9eafbe0f6267a3031e6b0834f7911cbb2"
+  },
+  "content_roots": [
+    "app",
+    "components",
+    "content",
+    "data",
+    "lib",
+    "pages",
+    "src"
+  ],
+  "generated_files": [
+    "CREATOR.md",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "GEMINI.md",
+    ".github/copilot-instructions.md",
+    ".cursor/rules/editorial.mdc",
+    ".agents/skills/frank-brand-editor/SKILL.md",
+    ".github/workflows/starlight-editorial-contract.yml",
+    ".starlight/editorial-contract.json"
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,16 @@ For any site, app, landing page, dashboard, visual identity, brand, motion, medi
 
 When motion, scroll, generated media, GIF/video, or premium polish matters, route through the Motion Design Studio plugin/skills and verify the result visually.
 
+<!-- STARLIGHT-EDITORIAL:START -->
+## Editorial contract
+
+Brand: **AI Architect Academy** (`ai-architect-academy`)
+
+- Read `CREATOR.md` before changing public or customer-facing copy.
+- Apply the registered brand voice and the shared editorial gate.
+- Reject generated prestige language, rhetorical contrast formulas, invented claims, and abstract labels that hide simple facts.
+- Keep public labels in sentence case.
+- Run the changed-copy editorial audit before release.
+
+Pinned source: https://github.com/frankxai/starlight-design-intelligence/blob/50ae34c7ac06e6c083f277ca96c3bde8f0a39b43/brand-packs/ai-architect-academy/COPY.md
+<!-- STARLIGHT-EDITORIAL:END -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,3 +239,17 @@ ai-architect-academy/
 ---
 
 *Built by FrankX. Powered by Claude Code. The medium is the message.*
+
+<!-- STARLIGHT-EDITORIAL:START -->
+## Editorial contract
+
+Brand: **AI Architect Academy** (`ai-architect-academy`)
+
+- Read `CREATOR.md` before changing public or customer-facing copy.
+- Apply the registered brand voice and the shared editorial gate.
+- Reject generated prestige language, rhetorical contrast formulas, invented claims, and abstract labels that hide simple facts.
+- Keep public labels in sentence case.
+- Run the changed-copy editorial audit before release.
+
+Pinned source: https://github.com/frankxai/starlight-design-intelligence/blob/50ae34c7ac06e6c083f277ca96c3bde8f0a39b43/brand-packs/ai-architect-academy/COPY.md
+<!-- STARLIGHT-EDITORIAL:END -->

--- a/CREATOR.md
+++ b/CREATOR.md
@@ -1,0 +1,33 @@
+<!-- STARLIGHT-EDITORIAL:START -->
+# AI Architect Academy voice
+
+Pinned source: https://github.com/frankxai/starlight-design-intelligence/blob/50ae34c7ac06e6c083f277ca96c3bde8f0a39b43/brand-packs/ai-architect-academy/COPY.md
+
+# AI Architect Academy editorial language
+
+## Reader and decision
+
+Write for senior engineers, solution architects, technical founders, and enterprise AI leaders. The reader should sharpen a decision and be able to defend it in production.
+
+## Voice
+
+- Rigorous, opinionated, technical, and economical.
+- Tie each architectural choice to security, cost, latency, ownership, and operations.
+- Date version-sensitive claims.
+- Prefer primary documentation and reproducible examples.
+- Use diagrams when relationships require them.
+
+## Avoid
+
+- Beginner filler and framework worship.
+- Vendor catalogues presented as analysis.
+- Decorative complexity.
+- Grand future claims with no production consequence.
+- Unexplained acronyms and abstract labels.
+
+## Examples
+
+“Choose the memory boundary before the vector database. It determines privacy, deletion, and evaluation.”
+
+“An agent without observable state remains a demo you cannot operate.”
+<!-- STARLIGHT-EDITORIAL:END -->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,13 @@
+<!-- STARLIGHT-EDITORIAL:START -->
+## Editorial contract
+
+Brand: **AI Architect Academy** (`ai-architect-academy`)
+
+- Read `CREATOR.md` before changing public or customer-facing copy.
+- Apply the registered brand voice and the shared editorial gate.
+- Reject generated prestige language, rhetorical contrast formulas, invented claims, and abstract labels that hide simple facts.
+- Keep public labels in sentence case.
+- Run the changed-copy editorial audit before release.
+
+Pinned source: https://github.com/frankxai/starlight-design-intelligence/blob/50ae34c7ac06e6c083f277ca96c3bde8f0a39b43/brand-packs/ai-architect-academy/COPY.md
+<!-- STARLIGHT-EDITORIAL:END -->


### PR DESCRIPTION
Installs the AI Architect Academy editorial contract pinned to `50ae34c7ac06e6c083f277ca96c3bde8f0a39b43`.

- preserves existing agent instructions through managed blocks
- autoloads the contract for Codex, Claude, Gemini, Cursor, and Copilot
- installs the repository-local brand editor skill
- blocks new public-copy hard failures through changed-line CI

Canonical source: frankxai/starlight-design-intelligence#14